### PR TITLE
Allow environment-configurable KVM binary name

### DIFF
--- a/libexec/start-target
+++ b/libexec/start-target
@@ -14,7 +14,8 @@ fi
 
 case $VMSW in
   KVM)
-    kvm -cpu $ARCH -m ${VMEM:-2000} -smp ${NPROCS:-2} -drive file=target-$SUFFIX.qcow2,cache=writeback -net nic,model=virtio -net user,hostfwd=tcp:127.0.0.1:$VM_SSH_PORT-:22 -vnc 127.0.0.1:16 > var/target.log 2>&1 &
+    [ -n "$KVM" ] || KVM=kvm
+    $KVM -cpu $ARCH -m ${VMEM:-2000} -smp ${NPROCS:-2} -drive file=target-$SUFFIX.qcow2,cache=writeback -net nic,model=virtio -net user,hostfwd=tcp:127.0.0.1:$VM_SSH_PORT-:22 -vnc 127.0.0.1:16 > var/target.log 2>&1 &
     echo $! > var/target.pid
     wait
     rm var/target.pid


### PR DESCRIPTION
Gentoo's is called qemu-system-x86_64 or qemu-system-i386 depending on native platform.
