### PR TITLE
Bugfix: git fetch directly from the remote URL, rather than only setting a default the first time

### DIFF
--- a/bin/gbuild
+++ b/bin/gbuild
@@ -196,9 +196,8 @@ build_desc["remotes"].each do |remote|
   dir = sanitize(remote["dir"], remote["dir"])
   unless File.exist?("inputs/#{dir}")
       system!("git init inputs/#{dir}")
-      system!("cd inputs/#{dir} && git remote add origin #{sanitize_path(remote["url"], remote["url"])}")
   end
-  system!("cd inputs/#{dir} && git fetch && git fetch --tags")
+  system!("cd inputs/#{dir} && git fetch #{sanitize_path(remote["url"], remote["url"])} +refs/tags/*:refs/tags/* +refs/heads/*:refs/heads/*")
   commit = sanitize(remote["commit"], remote["commit"])
   commit = `cd inputs/#{dir} && git log --format=%H -1 #{commit}`.strip
   raise "error looking up commit for tag #{remote["commit"]}" unless $?.exitstatus == 0


### PR DESCRIPTION
- Fixes problem where the gitian URL varies for different branches of the same repository
- Explicitly fetching tags using + allows repository to overwrite existing tags (changed tag)
- Fetching branch heads to local heads correctly makes branch names available for commit option
- Fetching both branches and tags at the same time optimizes things slightly
