### PR TITLE
Increase time for checking if a target has started.

### DIFF
--- a/bin/gbuild
+++ b/bin/gbuild
@@ -62,7 +62,7 @@ def build_one_configuration(suite, arch, build_desc, reference_datetime)
 
   $stdout.write "Checking if target is up"
 
-  (1..10).each do
+  (1..30).each do
     system "on-target true 2> /dev/null" and break
     sleep 2
     $stdout.write '.'


### PR DESCRIPTION
I ran into issues where the VM sometimes took longer than 20 seconds to start, which subsequently caused the SSH connection to be refused and the build aborted.

There's no reason why it could just be set a bit longer.
