### PR TITLE
Fix issue #56: clean up environment before gbuild'ing

### DIFF
--- a/bin/gbuild
+++ b/bin/gbuild
@@ -94,6 +94,8 @@ def build_one_configuration(suite, arch, build_desc, reference_datetime)
   File.open("var/build-script", "w") do |script|
     script.puts "#!/bin/bash"
     script.puts "set -e"
+    script.puts "export LANG='en_US.UTF-8'"
+    script.puts "export LC_ALL='en_US.UTF-8'"
     script.puts "umask 002"
     script.puts "export OUTDIR=$HOME/out"
     script.puts "GBUILD_BITS=#{bits}"


### PR DESCRIPTION
Sets LC_ALL and LANG overrides, preventing issues like #53. This is a direct fix to #56, originally proposed by cfields.
