### PR TITLE
Use a clean environment when building VMs

### DIFF
--- a/bin/make-base-vm
+++ b/bin/make-base-vm
@@ -106,7 +106,7 @@ fi
 
 libexec/config-bootstrap-fixup
 rm -rf $OUT
-sudo vmbuilder kvm ubuntu --rootsize 10240 --arch=$ARCH --suite=$SUITE --addpkg=$addpkg --removepkg=$removepkg --ssh-key=var/id_dsa.pub --ssh-user-key=var/id_dsa.pub --mirror=$MIRROR --security-mirror=$SECURITY_MIRROR --dest=$OUT --flavour=$FLAVOUR --firstboot=`pwd`/target-bin/bootstrap-fixup
+env -i LANG=en_US.UTF-8 LC_ALL=en_US.UTF-8 sudo vmbuilder kvm ubuntu --rootsize 10240 --arch=$ARCH --suite=$SUITE --addpkg=$addpkg --removepkg=$removepkg --ssh-key=var/id_dsa.pub --ssh-user-key=var/id_dsa.pub --mirror=$MIRROR --security-mirror=$SECURITY_MIRROR --dest=$OUT --flavour=$FLAVOUR --firstboot=`pwd`/target-bin/bootstrap-fixup
 mv $OUT/*.qcow2 $OUT.qcow2
 rm -rf $OUT
 


### PR DESCRIPTION
This will fix problem reported by Luke-Jr.

Nonetheless, already-generated VMs should be discarded because before this fix they can be polluted by host environment.
