### PR TITLE
Allow @ in URLs

### DIFF
--- a/bin/gbuild
+++ b/bin/gbuild
@@ -27,7 +27,7 @@ def sanitize(str, where)
 end
 
 def sanitize_path(str, where)
-  raise "unsanitary string in #{where}" if (str =~ /[^\w\/.:+-]/)
+  raise "unsanitary string in #{where}" if (str =~ /[^@\w\/.:+-]/)
   str
 end
 

--- a/bin/gsign
+++ b/bin/gsign
@@ -17,7 +17,7 @@ def sanitize(str, where)
 end
 
 def sanitize_path(str, where)
-  raise "unsanitary string in #{where}" if (str =~ /[^\w\/.-]/)
+  raise "unsanitary string in #{where}" if (str =~ /[^@\w\/.:+-]/)
   str
 end
 

--- a/bin/gverify
+++ b/bin/gverify
@@ -17,7 +17,7 @@ def sanitize(str, where)
 end
 
 def sanitize_path(str, where)
-  raise "unsanitary string in #{where}" if (str =~ /[^@\w\/. -]/)
+  raise "unsanitary string in #{where}" if (str =~ /[^@\w\/.:+-]/)
   str
 end
 


### PR DESCRIPTION
Without this patch, Gitian-Builder fails with an _unsanitary string_ error in `gbuild` when pulling down source code stored on BitBucket.org. The same change is needed for `gsign` and `gverify` when run against signature repositories also on BitBucket.

`gsign` and `gverify` were also updated to allow the full range of characters accepted by `gbuild` as previously fixed in 8ad9e0dfaf4fff357e972c80960cd416c226ab4d.
