### PR TITLE
cache fixes

### DIFF
--- a/bin/gbuild
+++ b/bin/gbuild
@@ -259,9 +259,11 @@ suites.each do |suite|
 end
 
 out_dir = File.join(build_dir, "out")
+out_sums = {}
 cache_common_dir = File.join(cache_dir, "common")
 cache_package_dir = File.join(cache_dir, "#{package_name}")
-out_sums = {}
+cache_common_sums = {}
+cache_package_sums = {}
 
 info "Generating report"
 Dir.glob(File.join(out_dir, '**', '*'), File::FNM_DOTMATCH).sort.each do |file_in_out|
@@ -277,29 +279,32 @@ Dir.glob(File.join(cache_common_dir, '**', '*'), File::FNM_DOTMATCH).sort.each d
   next if File.directory?(file_in_out)
   file = file_in_out.sub(cache_common_dir + File::SEPARATOR, '')
   file = sanitize_path(file, file_in_out)
-  out_sums[file] = `cd #{cache_common_dir} && sha256sum #{file}`
+  cache_common_sums[file] = `cd #{cache_common_dir} && sha256sum #{file}`
   raise "failed to sum #{file}" unless $? == 0
-  puts out_sums[file] unless @options[:quiet]
 end
 
 Dir.glob(File.join(cache_package_dir, '**', '*'), File::FNM_DOTMATCH).sort.each do |file_in_out|
   next if File.directory?(file_in_out)
   file = file_in_out.sub(cache_package_dir + File::SEPARATOR, '')
   file = sanitize_path(file, file_in_out)
-  out_sums[file] = `cd #{cache_package_dir} && sha256sum #{file}`
+  cache_package_sums[file] = `cd #{cache_package_dir} && sha256sum #{file}`
   raise "failed to sum #{file}" unless $? == 0
-  puts out_sums[file] unless @options[:quiet]
 end
 
 out_manifest = out_sums.keys.sort.map { |key| out_sums[key] }.join('')
 
 in_manifest = in_sums.join('')
 
+cache_common_manifest = cache_common_sums.keys.sort.map { |key| cache_common_sums[key] }.join('')
+cache_package_manifest = cache_package_sums.keys.sort.map { |key| cache_package_sums[key] }.join('')
+
 # Use Omap to keep result deterministic
 report = YAML::Omap[
   'out_manifest', out_manifest,
   'in_manifest', in_manifest,
   'base_manifests', base_manifests,
+  'cache_common_manifest', cache_common_manifest,
+  'cache_package_manifest', cache_package_manifest,
 ]
 
 result_file = "#{package_name}-res.yml"


### PR DESCRIPTION
After thorough testing while working on Bitcoin's replacement descriptors that take advantage of the cache, these issues came up. See individual commit messages and doc change for description.
- Fix broken builds when no cache is present
- Fix resulting yml determinism when cache is present
