### PR TITLE
Fix issue #63: use lxc-execute instead of lxc-start

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,13 +138,13 @@ TODO:
 
 ## LXC tips
 
-`bin/gbuild` runs `lxc-start`, which may require root.  If you are in the admin group, you can add the following sudoers line to prevent asking for the password every time:
+`bin/gbuild` runs `lxc-execute`, which may require root.  If you are in the admin group, you can add the following sudoers line to prevent asking for the password every time:
 
-    %admin ALL=NOPASSWD: /usr/bin/lxc-start
+    %admin ALL=NOPASSWD: /usr/bin/lxc-execute
 
-Recent distributions allow lxc-start to be run by non-priviledged users, so you might be able to rip-out the `sudo` calls in `libexec/*`.
+Recent distributions allow lxc-execute to be run by non-priviledged users, so you might be able to rip-out the `sudo` calls in `libexec/*`.
 
-If you have a runaway `lxc-start` command, just use `kill -9` on it.
+If you have a runaway `lxc-execute` command, just use `kill -9` on it.
 
 The machine configuration requires access to br0 and assumes that the host address is `10.0.2.2`:
 

--- a/bin/make-base-vm
+++ b/bin/make-base-vm
@@ -74,7 +74,7 @@ if [ $ARCH = "amd64" -a $SUITE = "hardy" ]; then
   FLAVOUR=server
 fi
 
-addpkg=openssh-server,pciutils,build-essential,git-core,subversion
+addpkg=openssh-server,pciutils,build-essential,git-core,subversion,lxc
 
 # Remove cron to work around vmbuilder issue when umounting /dev on target
 removepkg=cron

--- a/libexec/copy-from-target
+++ b/libexec/copy-from-target
@@ -50,5 +50,5 @@ if [ -z "$USE_LXC" ]; then
     scp $QUIET_FLAG -oConnectTimeout=30 -oNoHostAuthenticationForLocalhost=yes -i ${GITIAN_BASE:-.}/var/id_dsa -P $VM_SSH_PORT -r $TUSER@localhost:$1 $2
 else
     config-lxc
-    sudo lxc-start -n gitian -f var/lxc.config -- sudo -i -u $TUSER tar -cf - "$1" | tar -C "$2" -xkf -
+    sudo lxc-execute -n gitian -f var/lxc.config -- sudo -i -u $TUSER tar -cf - "$1" | tar -C "$2" -xkf -
 fi

--- a/libexec/copy-to-target
+++ b/libexec/copy-to-target
@@ -50,5 +50,5 @@ if [ -z "$USE_LXC" ]; then
     scp $QUIET_FLAG -r -oConnectTimeout=30 -oNoHostAuthenticationForLocalhost=yes -i ${GITIAN_BASE:-.}/var/id_dsa -P $VM_SSH_PORT $1 $TUSER@localhost:$2
 else
     config-lxc
-    tar -C `dirname "$1"` -cf - `basename "$1"` | sudo lxc-start -n gitian -f var/lxc.config -- sudo -i -u $TUSER tar -C "$2" -xf -
+    tar -C `dirname "$1"` -cf - `basename "$1"` | sudo lxc-execute -n gitian -f var/lxc.config -- sudo -i -u $TUSER tar -C "$2" -xf -
 fi

--- a/libexec/on-target
+++ b/libexec/on-target
@@ -50,5 +50,5 @@ if [ -z "$USE_LXC" ]; then
     ssh -oConnectTimeout=30 -oNoHostAuthenticationForLocalhost=yes -i ${GITIAN_BASE:-.}/var/id_dsa -p $VM_SSH_PORT $TUSER@localhost $*
 else
     config-lxc
-    sudo lxc-start -n gitian -f var/lxc.config -- sudo -u $TUSER $ENV -i -- $*
+    sudo lxc-execute -n gitian -f var/lxc.config -- sudo -u $TUSER $ENV -i -- $*
 fi


### PR DESCRIPTION
Here's a first attempt at fixing issue #63. It probably needs additional testing -- I've only tested it with Ubuntu 14.04.1 as the host, and with LXC_SUITE=precise,LXC_ARCH=amd64 and LXC_SUITE=precise,LXC_ARCH=i386 as two guests (I ran through a single gbuild for each and checked that the outputs matched a known good one).
