### PR TITLE
cache: define variables for cache paths

### DIFF
--- a/bin/gbuild
+++ b/bin/gbuild
@@ -109,6 +109,8 @@ def build_one_configuration(suite, arch, build_desc, reference_datetime)
     script.puts "umask 002"
     script.puts "export OUTDIR=$HOME/out"
     script.puts "GBUILD_BITS=#{bits}"
+    script.puts "GBUILD_PACKAGE_CACHE=$HOME/cache/#{build_desc["name"]}"
+    script.puts "GBUILD_COMMON_CACHE=$HOME/cache/common"
     script.puts "MAKEOPTS=(-j#{@options[:num_procs]})"
     (ref_date, ref_time) = reference_datetime.split
     script.puts "REFERENCE_DATETIME='#{reference_datetime}'"


### PR DESCRIPTION
As title suggests. Scripts may need to be aware of their cache paths without guessing. Necessary for bitcoin's (still) upcoming https://github.com/bitcoin/bitcoin/pull/4727
