### PR TITLE
git: minimize uploaded git files

### DIFF
--- a/bin/gbuild
+++ b/bin/gbuild
@@ -231,12 +231,15 @@ build_desc["remotes"].each do |remote|
   dir = sanitize(remote["dir"], remote["dir"])
   unless File.exist?("inputs/#{dir}")
       system!("git init inputs/#{dir}")
+      system!("cd inputs/#{dir} && git config core.logAllRefUpdates false")
   end
-  system!("cd inputs/#{dir} && git fetch --update-head-ok #{sanitize_path(remote["url"], remote["url"])} +refs/tags/*:refs/tags/* +refs/heads/*:refs/heads/*")
+  system!("cd inputs/#{dir} && git fetch -q #{sanitize_path(remote["url"], remote["url"])} +refs/tags/*:refs/remotes/tags/* +refs/heads/*:refs/remotes/heads/*")
   commit = sanitize(remote["commit"], remote["commit"])
   commit = `cd inputs/#{dir} && git log --format=%H -1 #{commit}`.strip
   raise "error looking up commit for tag #{remote["commit"]}" unless $?.exitstatus == 0
-  system!("cd inputs/#{dir} && git checkout -q #{commit}")
+  system!("cd inputs/#{dir} && git update-ref HEAD #{commit}")
+  system!("cd inputs/#{dir} && git repack -a -d -q")
+  system!("cd inputs/#{dir} && git pack-refs --all")
   in_sums << "git:#{commit} #{dir}"
 end
 


### PR DESCRIPTION
Rather than uploading every checked-out file of a repository and the
repository objects themselves, skip the checkout and instruct git to compact
before upload. The result is that only a handful of files are transferred,
rather than hundreds or thousands for large repositories.

The HEAD ref is updated before upload so that a hard reset works as before on
the target. The reflog is also disabled in order to avoid uploading useless log
files.

This change is backwards-compatible, but it will only have an effect on new
repositories.
