### PR TITLE
cache: define cache paths and GBUILD_CACHE_ENABLED conditionally

### DIFF
--- a/bin/gbuild
+++ b/bin/gbuild
@@ -109,8 +109,11 @@ def build_one_configuration(suite, arch, build_desc, reference_datetime)
     script.puts "umask 002"
     script.puts "export OUTDIR=$HOME/out"
     script.puts "GBUILD_BITS=#{bits}"
-    script.puts "GBUILD_PACKAGE_CACHE=$HOME/cache/#{build_desc["name"]}"
-    script.puts "GBUILD_COMMON_CACHE=$HOME/cache/common"
+    if build_desc["enable_cache"]
+      script.puts "GBUILD_CACHE_ENABLED=1"
+      script.puts "GBUILD_PACKAGE_CACHE=$HOME/cache/#{build_desc["name"]}"
+      script.puts "GBUILD_COMMON_CACHE=$HOME/cache/common"
+    end
     script.puts "MAKEOPTS=(-j#{@options[:num_procs]})"
     (ref_date, ref_time) = reference_datetime.split
     script.puts "REFERENCE_DATETIME='#{reference_datetime}'"

--- a/doc/CACHE
+++ b/doc/CACHE
@@ -5,14 +5,17 @@ is enabled in the build descriptor.
 Common cache:
 All descriptors share this cache. It can be useful for storing fetched sources,
 sharing build assets between descriptors, etc.
-To add or update files, copy them to ~/cache/common from the build script.
 
 Per-descriptor cache
 Files installed to this cache can only be seen by this descriptor. Use this to
 store assets created as part of the build process, to avoid having to rebuild
 them in future builds.
-To add or update files, copy them to ~/cache/$NAME from the build script, where
-$NAME is the value of the descriptor's "name" key.
+
+If caching is enabled, GBUILD_CACHE_ENABLED will be set to 1 in the build
+script. In addition, GBUILD_PACKAGE_CACHE and GBUILD_COMMON_CACHE will be set
+to their respective paths. GBUILD_PACKAGE_CACHE contains the descriptor's
+"name" key as a means of separating caches. To add or update the cached files,
+copy them to  these paths.
 
 Before each build, all files and folders in the cache directories will be
 transferred to the VM. After each successful build, the caches will be


### PR DESCRIPTION
Follow-up of 66015b9f14387295de4b8850097e510578cac651. This will allow build-scripts to detect caching, so they can continue to work with older gitian versions. Sorry for not including it in #71.

This really should be the last change needed for Bitcoin's cache usage.
