### PR TITLE
fix copy-from-target when using lxc to copy a subdir

### DIFF
--- a/libexec/copy-from-target
+++ b/libexec/copy-from-target
@@ -50,5 +50,5 @@ if [ -z "$USE_LXC" ]; then
     scp $QUIET_FLAG -oConnectTimeout=30 -oNoHostAuthenticationForLocalhost=yes -i ${GITIAN_BASE:-.}/var/id_dsa -P $VM_SSH_PORT -r $TUSER@localhost:$1 $2
 else
     config-lxc
-    sudo $LXC_EXECUTE -n gitian -f var/lxc.config -- sudo -i -u $TUSER tar -cf - "$1" | tar -C "$2" -xkf -
+    sudo $LXC_EXECUTE -n gitian -f var/lxc.config -- sudo -i -u $TUSER tar -C `dirname "$1"` -cf - `basename "$1"` | tar -C "$2" -xkf -
 fi


### PR DESCRIPTION
Addresses #78. copy-from-target has probably always been broken in this case for lxc, it's just gone unnoticed since there was no subdir copy before the cache.
