### PR TITLE
prevent upgrade of grub-pc which can fail in lxc

### DIFF
--- a/target-bin/grab-packages.sh
+++ b/target-bin/grab-packages.sh
@@ -7,6 +7,7 @@ set -e
 cd /var/cache/apt/archives
 
 # make sure all packages with installed versions are downloaded
-dpkg-query -W -f '${Package}=${Version}\n' | xargs -n 50 apt-get install -q --reinstall -y -d > /tmp/download.log
+# (except for held packages, which may not be available for download)
+dpkg-query -W -f '${Status}\t${Package}=${Version}\n' | grep -v ^hold | cut -f2- | xargs -n 50 apt-get install -q --reinstall -y -d > /tmp/download.log
 grep "cannot be downloaded" /tmp/download.log && { echo Could not download some packages, please run gbuild --upgrade 1>&2 ; exit 1 ; }
 sha256sum *.deb | sort --key 2

--- a/target-bin/upgrade-system.sh
+++ b/target-bin/upgrade-system.sh
@@ -9,6 +9,9 @@ mkdir -p /var/cache/gitian
 # remove obsolete grub, it causes package dependency issues
 apt-get -q -y purge grub > /dev/null 2>&1 || true
 
+# prevent upgrade of grub-pc, it fails to find a boot drive in lxc containers
+echo grub-pc hold | dpkg --set-selections || true
+
 # upgrade packages
 DEBIAN_FRONTEND=noninteractive apt-get -y dist-upgrade > /dev/null > /var/cache/gitian/upgrade.log 2>&1
 


### PR DESCRIPTION
This PR attempts to close #86.

It simply places a dpkg hold on grub-pc in `upgrade-system.sh` to prevent its upgrade. This should be a fairly conservative approach.

Unfortunately, when `grab-packages.sh` tries to download grub-pc via `apt-get install -q --reinstall -y -d grub-pc`, `apt-get` fails due to the hold. It could remove the hold first (and that works today), but there's no guarantee that old packages will remain available in the archive, so the safer approach was to prevent any held packages from being downloaded. On the slight negative side, this changes the manifest.