### PR TITLE
Add ECDSA signing to gsign

### DIFF
--- a/bin/gsign
+++ b/bin/gsign
@@ -45,6 +45,14 @@ OptionParser.new do |opts|
   opts.on("-d DEST", "--destination DEST", "directory to place signature in") do |v|
     @options[:destination] = v
   end
+
+  opts.on("-e", "--ecdsa", "enable ecdsa signing instead of gpg") do |v|
+    @options[:ecdsa] = v
+  end
+
+  opts.on("-a PATH", "--armory PATH", "path to Armory source tree") do |v|
+    @options[:armory] = v
+  end
 end.parse!
 
 base_dir = Pathname.new(__FILE__).expand_path.dirname.parent
@@ -75,7 +83,9 @@ result['name'] = package_name
 result['type'] = 'build'
 result['optionals'] = optionals
 
-signer = @options[:signer] or raise "must supply signer with --signer"
+unless @options[:ecdsa]
+  signer = @options[:signer] or raise "must supply signer with --signer"
+end
 
 FileUtils.mkdir_p(destination)
 
@@ -85,4 +95,9 @@ assert_path = File.join(release_path, "#{package_name}-build.assert")
 File.open(assert_path, "w") do |io|
   io.write result.to_yaml
 end
-system!("gpg --detach-sign -u \"#{signer}\" \"#{assert_path}\"")
+if @options[:ecdsa]
+  ecdsa_path = File.join(@options[:armory], release_scripts, "signassert.py")
+  system("python #{ecdsa_path} \"#{assert_path}\"")
+else
+  system!("gpg --detach-sign -u \"#{signer}\" \"#{assert_path}\"")
+end

--- a/bin/gsign
+++ b/bin/gsign
@@ -46,12 +46,8 @@ OptionParser.new do |opts|
     @options[:destination] = v
   end
 
-  opts.on("-e", "--ecdsa", "enable ecdsa signing instead of gpg") do |v|
-    @options[:ecdsa] = v
-  end
-
-  opts.on("-a PATH", "--armory PATH", "path to Armory source tree") do |v|
-    @options[:armory] = v
+  opts.on("-p PROG", "--signing_program PROG", "specify signing program to use") do |v|
+    @options[:program] = v
   end
 end.parse!
 
@@ -83,9 +79,8 @@ result['name'] = package_name
 result['type'] = 'build'
 result['optionals'] = optionals
 
-unless @options[:ecdsa]
-  signer = @options[:signer] or raise "must supply signer with --signer"
-end
+signer = @options[:signer] or raise "must supply signer with --signer"
+program = @options[:program] || "gpg --detach-sign"
 
 FileUtils.mkdir_p(destination)
 
@@ -95,9 +90,4 @@ assert_path = File.join(release_path, "#{package_name}-build.assert")
 File.open(assert_path, "w") do |io|
   io.write result.to_yaml
 end
-if @options[:ecdsa]
-  ecdsa_path = File.join(@options[:armory], release_scripts, "signassert.py")
-  system("python #{ecdsa_path} \"#{assert_path}\"")
-else
-  system!("gpg --detach-sign -u \"#{signer}\" \"#{assert_path}\"")
-end
+system("#{program} -u \"#{signer}\" \"#{assert_path}\"")

--- a/bin/gsign
+++ b/bin/gsign
@@ -90,4 +90,4 @@ assert_path = File.join(release_path, "#{package_name}-build.assert")
 File.open(assert_path, "w") do |io|
   io.write result.to_yaml
 end
-system("#{program} -u \"#{signer}\" \"#{assert_path}\"")
+system!("#{program} -u \"#{signer}\" \"#{assert_path}\"")


### PR DESCRIPTION
This PR is intended to add the option to gsign to use ECDSA for signing instead of invoking gpg. This feature is useful for Armory, which will be using these tools for reproducible builds. Armory is able to verify ECDSA signatures much easier using its Secure Downloader than it is able to use gpg to verify signatures.

This relies on a script in the Armory source tree to handle the actual signing. That script does not exist yet. I opened this pull request just to get feedback at this time concerning how to handle the connection to Armory to do the actual signing. Besides the way this PR currently does things, there were also the ideas brought up of adding an API/plugin interface or a configuration file to gitian-builder to allow arbitrary signing algorithm/program combinations to be added. That may be overkill. Who knows whether someone will ever want to add a new algorithm and/or program in the future. I'd like feedback on those ideas and on the way the PR works now.

This PR is untested, because I don't have the script that will actually handle the signing yet, so this shouldn't be merged until that script is done.

As for how the script itself will work, it will need to request a number of things. It will request an Armory wallet code (the user will need to have run Armory and created a wallet beforehand), an address in the wallet with which to sign, and the wallet passphrase. Then the script will sign the assert file that was passed through from gsign.