### PR TITLE
gbuild: Allow disabling fetch of modified caches with `--cache-read-only` option

### DIFF
--- a/bin/gbuild
+++ b/bin/gbuild
@@ -156,6 +156,9 @@ OptionParser.new do |opts|
   opts.on("-u PAIRS", "--url PAIRS", "comma separated list of DIRECTORY=URL pairs") do |v|
     @options[:url] = v
   end
+  opts.on("--cache-read-only", "only use existing cache files, do not update them") do |v|
+    @options[:cache_ro] = v
+  end
 end.parse!
 
 if !ENV["USE_LXC"] and !File.exist?("/dev/kvm")
@@ -259,10 +262,12 @@ suites.each do |suite|
     info "Grabbing results"
     system! "copy-from-target #{@quiet_flag} out #{build_dir}"
 
+    unless @options[:cache_ro]
     if enable_cache
       info "Grabbing cache"
       system! "copy-from-target #{@quiet_flag} cache/#{package_name}/ #{cache_dir}"
       system! "copy-from-target #{@quiet_flag} cache/common/ #{cache_dir}"
+    end
     end
     base_manifest = File.read("var/base-#{suite}-#{arch}.manifest")
     base_manifests["#{suite}-#{arch}"] = base_manifest


### PR DESCRIPTION
I find this useful for building potentially-untrusted Bitcoin forks without risking polluting the Bitcoin caches.