### PR TITLE
Readme.md OSX Homebrew addition

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,11 @@ On Debian Wheezy you run the same command, but you must first add backports to y
 
     sudo port install ruby coreutils
     export PATH=$PATH:/opt/local/libexec/gnubin  # Needed for sha256sum
+    
+### OSX with Homebrew:
+
+    brew install ruby coreutils
+    export PATH=$PATH:/opt/local/libexec/gnubin    
 
 #### VirtualBox:
 


### PR DESCRIPTION
I just added the 'Homebrew' commands for those that prefer Homebrew over MacPorts on OSX, as switching between the two once you already use another one can be a pain and cause problems with packages you use them for.