### PR TITLE
Missing wget

### DIFF
--- a/bin/make-base-vm
+++ b/bin/make-base-vm
@@ -74,7 +74,7 @@ if [ $ARCH = "amd64" -a $SUITE = "hardy" ]; then
   FLAVOUR=server
 fi
 
-addpkg=pciutils,build-essential,git-core,subversion,language-pack-en
+addpkg=pciutils,build-essential,git-core,subversion,language-pack-en,wget
 
 if [ $LXC = "1" ]; then
   addpkg=$addpkg,lxc


### PR DESCRIPTION
The build process for [Bitcoin](https://github.com/bitcoin/bitcoin/blob/master/doc/gitian-building.md) was failing with the following error

```
./bin/gbuild:21:in `system!': failed to run on-target setarch x86_64 bash -x < var/build-script > var/build.log 2>&1 (RuntimeError)
        from ./bin/gbuild:137:in `build_one_configuration'
        from ./bin/gbuild:267:in `block (2 levels) in <main>'
        from ./bin/gbuild:262:in `each'
        from ./bin/gbuild:262:in `block in <main>'
        from ./bin/gbuild:260:in `each'
        from ./bin/gbuild:260:in `<main>'
```

Inside the log file `var/build.log` the entries towards the end show

```
/bin/sh: 1: wget: not found
```