### PR TITLE
Use lsb_release to get codename rather than /etc/lsb-release

### DIFF
--- a/bin/make-base-vm
+++ b/bin/make-base-vm
@@ -74,7 +74,7 @@ if [ $ARCH = "amd64" -a $SUITE = "hardy" ]; then
   FLAVOUR=server
 fi
 
-addpkg=pciutils,build-essential,git-core,subversion,language-pack-en,wget
+addpkg=pciutils,build-essential,git-core,subversion,language-pack-en,wget,lsb-release
 
 if [ $LXC = "1" ]; then
   addpkg=$addpkg,lxc

--- a/target-bin/bootstrap-fixup.in
+++ b/target-bin/bootstrap-fixup.in
@@ -2,7 +2,7 @@
 
 set -e
 
-. /etc/lsb-release
+DISTRIB_CODENAME=`lsb_release -cs`
 
 echo "deb http://HOSTIP:3142/archive.ubuntu.com/ubuntu $DISTRIB_CODENAME main universe" > $1/etc/apt/sources.list
 echo "deb http://HOSTIP:3142/security.ubuntu.com/ubuntu $DISTRIB_CODENAME-security main universe" >> $1/etc/apt/sources.list


### PR DESCRIPTION
It seems like a lsb_release program should be available on any distro if
the appropriate package is installed. So it seems better to use
lsb_release instead of /etc/lsb-release, because Debian doesn't appear
to have /etc/lsb-release.

Let me know if you would rather just have me submit this along with all the other changes needed for Debian guest support. I figured that this is not directly related to Debian guest support, so I would file this separate PR, but it is something that isn't an issue if Ubuntu is the only guest supported.