### PR TITLE
Initial Debian guest support

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,22 @@ On Debian Wheezy you run the same command, but you must first add backports to y
 
 Install virtualbox from http://www.virtualbox.org, and make sure `VBoxManage` is in your `$PATH`.
 
+## Debian Guests
+
+Gitian now supports Debian guests in addition to Ubuntu guests. Note that this doesn't mean you can allow the builders to choose to use either Debian or Ubuntu guests. The person creating the Gitian descriptor will need to choose a particular distro and suite for the guest and all builders must use that particular distro and suite, otherwise the software won't reproduce for everyone.
+
+The official vmbuilder only includes support for Ubuntu guests, so you need to install [Joseph Bisch's fork of vmbuilder](https://github.com/josephbisch/vmbuilder), which adds a Debian plugin.
+
+To create a Debian guest:
+
+    bin/make-base-vm --distro debian --suite jessie
+
+There is currently no support for LXC Debian guests. There is just KVM support. LXC support for Debian guests is planned to be added soon.
+
+Only Debian Jessie guests have been tested with Gitian. Debian Jessie is the current stable release of Debian at this time. If you have success (or trouble) with other versions of Debian, please let us know.
+
+If you are creating a Gitian descriptor, you can now specify a distro. If no distro is provided, the default is to assume Ubuntu. Since Ubuntu is assumed, older Gitian descriptors that don't specify a distro will still work as they always have.
+
 ## Create the base VM for use in further builds
 **NOTE:** requires `sudo`, please review the script
 

--- a/bin/gbuild
+++ b/bin/gbuild
@@ -204,7 +204,7 @@ if enable_cache
   FileUtils.mkdir_p(File.join(cache_dir, package_name))
 end
 
-distro = build_desc["distro"] or raise "must supply distro"
+distro = build_desc["distro"] || "ubuntu"
 suites = build_desc["suites"] or raise "must supply suites"
 archs = build_desc["architectures"] or raise "must supply architectures"
 reference_datetime = build_desc["reference_datetime"] or raise "must supply reference_datetime"

--- a/bin/gbuild
+++ b/bin/gbuild
@@ -204,9 +204,12 @@ if enable_cache
   FileUtils.mkdir_p(File.join(cache_dir, package_name))
 end
 
+distro = build_desc["distro"] or raise "must supply distro"
 suites = build_desc["suites"] or raise "must supply suites"
 archs = build_desc["architectures"] or raise "must supply architectures"
 reference_datetime = build_desc["reference_datetime"] or raise "must supply reference_datetime"
+
+ENV['DISTRO'] = distro
 
 desc_sum = `sha256sum #{build_desc_file}`
 desc_sum = desc_sum.sub(build_desc_file, "#{package_name}-desc.yml")

--- a/bin/make-base-vm
+++ b/bin/make-base-vm
@@ -1,10 +1,10 @@
 #!/bin/sh
 set -e
 
+DISTRO=ubuntu
 SUITE=lucid
 ARCH=amd64
-MIRROR=http://${MIRROR_HOST:-127.0.0.1}:3142/archive.ubuntu.com/ubuntu
-SECURITY_MIRROR=http://${MIRROR_HOST:-127.0.0.1}:3142/security.ubuntu.com/ubuntu
+MIRROR_BASE=http://${MIRROR_HOST:-127.0.0.1}:3142
 LXC=0
 VBOX=0
 
@@ -13,11 +13,12 @@ usage() {
   echo "Make a base client."
   echo
   cat << EOF
-  --help     display this help and exit
-  --suite U  build suite U instead of lucid
-  --arch A   build architecture A (e.g. i386) instead of amd64
-  --lxc      use lxc instead of kvm
-  --vbox     use VirtualBox instead of kvm
+  --help      display this help and exit
+  --distro D  build distro D (e.g. debian) instead of ubuntu
+  --suite U   build suite U instead of lucid
+  --arch A    build architecture A (e.g. i386) instead of amd64
+  --lxc       use lxc instead of kvm
+  --vbox      use VirtualBox instead of kvm
 
   The MIRROR_HOST environment variable can be used to change the
   apt-cacher host.  It should be something that both the host and the
@@ -33,6 +34,10 @@ if [ $# != 0 ] ; then
       --help|-h)
         usage
         exit 0
+        ;;
+      --distro|-d)
+        DISTRO="$2"
+        shift 2
         ;;
       --suite|-s)
         SUITE="$2"
@@ -61,6 +66,19 @@ if [ $# != 0 ] ; then
   done
 fi
 
+if [ $DISTRO = "debian" -a $LXC = "1" ]; then
+  echo "There is no support for Debian guests using LXC currently. Please use KVM or another distro for now."
+  exit 1
+fi
+
+if [ $DISTRO = "ubuntu" ]; then
+  MIRROR=$MIRROR_BASE/archive.ubuntu.com/ubuntu
+  SECURITY_MIRROR=$MIRROR_BASE/security.ubuntu.com/ubuntu
+elif [ $DISTRO = "debian" ]; then
+  MIRROR=$MIRROR_BASE/ftp.debian.org/debian
+  SECURITY_MIRROR=$MIRROR_BASE/security.debian.org/
+fi
+
 mkdir -p var
 
 if [ ! -e var/id_dsa ]; then
@@ -74,12 +92,28 @@ if [ $ARCH = "amd64" -a $SUITE = "hardy" ]; then
   FLAVOUR=server
 fi
 
-addpkg=pciutils,build-essential,git-core,subversion,language-pack-en,wget,lsb-release
+if [ $DISTRO = "debian" -a $ARCH = "amd64" ]; then
+  FLAVOUR=amd64
+elif [ $DISTRO = "debian" -a $ARCH = "i386" ]; then
+  FLAVOUR=i686-pae
+fi
+
+LOCALE_PKG=language-pack-en
+if [ $DISTRO = "debian" ]; then
+  LOCALE_PKG=locales
+fi
+
+addpkg=pciutils,build-essential,git-core,subversion,$LOCALE_PKG,wget,lsb-release
+
+KERNEL_PKG=linux-image-generic
+if [ $DISTRO = "debian" ]; then
+  KERNEL_PKG=
+fi
 
 if [ $LXC = "1" ]; then
   addpkg=$addpkg,lxc
 else
-  addpkg=$addpkg,linux-image-generic,grub-pc,openssh-server
+  addpkg=$addpkg,$KERNEL_PKG,grub-pc,openssh-server
 fi
 
 # Remove cron to work around vmbuilder issue when umounting /dev on target
@@ -96,8 +130,8 @@ if [ $VBOX = "1" ]; then
 
   vagrant ssh "$NAME" -c "sudo mkdir -p /root/.ssh && sudo chmod 700 /root/.ssh"
   vagrant ssh "$NAME" -c "sudo sh -c 'cat >> /root/.ssh/authorized_keys'" < var/id_dsa.pub
-  vagrant ssh "$NAME" -c "sudo -u ubuntu mkdir -p /home/ubuntu/.ssh && sudo -u ubuntu chmod 700 /home/ubuntu/.ssh"
-  vagrant ssh "$NAME" -c "sudo sh -c 'cat >> /home/ubuntu/.ssh/authorized_keys'" < var/id_dsa.pub
+  vagrant ssh "$NAME" -c "sudo -u $DISTRO mkdir -p /home/$DISTRO/.ssh && sudo -u $DISTRO chmod 700 /home/$DISTRO/.ssh"
+  vagrant ssh "$NAME" -c "sudo sh -c 'cat >> /home/$DISTRO/.ssh/authorized_keys'" < var/id_dsa.pub
 
   VBoxManage snapshot "Gitian-$NAME" take "Gitian-Clean"
   vagrant suspend "$NAME"
@@ -132,7 +166,7 @@ else
   libexec/config-bootstrap-fixup
 
   rm -rf $OUT
-  env -i LANG=en_US.UTF-8 LC_ALL=en_US.UTF-8 sudo vmbuilder kvm ubuntu --rootsize 10240 --arch=$ARCH --suite=$SUITE --addpkg=$addpkg --removepkg=$removepkg --ssh-key=var/id_dsa.pub --ssh-user-key=var/id_dsa.pub --mirror=$MIRROR --security-mirror=$SECURITY_MIRROR --dest=$OUT --flavour=$FLAVOUR --firstboot=`pwd`/target-bin/bootstrap-fixup
+  env -i LANG=en_US.UTF-8 LC_ALL=en_US.UTF-8 sudo vmbuilder kvm $DISTRO --rootsize 10240 --arch=$ARCH --suite=$SUITE --addpkg=$addpkg --removepkg=$removepkg --ssh-key=var/id_dsa.pub --ssh-user-key=var/id_dsa.pub --mirror=$MIRROR --security-mirror=$SECURITY_MIRROR --dest=$OUT --flavour=$FLAVOUR --firstboot=`pwd`/target-bin/bootstrap-fixup
   mv $OUT/*.qcow2 $OUT.qcow2
   rm -rf $OUT
   # bootstrap-fixup is done on first boot

--- a/libexec/copy-from-target
+++ b/libexec/copy-from-target
@@ -2,7 +2,7 @@
 
 . gconfig
 
-TUSER=ubuntu
+TUSER=$DISTRO
 QUIET_FLAG=
 
 usage() {

--- a/libexec/copy-to-target
+++ b/libexec/copy-to-target
@@ -2,7 +2,7 @@
 
 . gconfig
 
-TUSER=ubuntu
+TUSER=$DISTRO
 QUIET_FLAG=
 
 usage() {

--- a/libexec/on-target
+++ b/libexec/on-target
@@ -2,7 +2,7 @@
 
 . gconfig
 
-TUSER=ubuntu
+TUSER=$DISTRO
 
 usage() {
   echo "Usage: ${0##*/} [OPTION]... <command>"

--- a/target-bin/bootstrap-fixup.in
+++ b/target-bin/bootstrap-fixup.in
@@ -2,11 +2,18 @@
 
 set -e
 
+DISTRIB_NAME=`lsb_release -is`
 DISTRIB_CODENAME=`lsb_release -cs`
 
-echo "deb http://HOSTIP:3142/archive.ubuntu.com/ubuntu $DISTRIB_CODENAME main universe" > $1/etc/apt/sources.list
-echo "deb http://HOSTIP:3142/security.ubuntu.com/ubuntu $DISTRIB_CODENAME-security main universe" >> $1/etc/apt/sources.list
-echo "deb http://HOSTIP:3142/archive.ubuntu.com/ubuntu $DISTRIB_CODENAME-updates main universe" >> $1/etc/apt/sources.list
+if [ $DISTRIB_NAME = "Ubuntu" ]; then
+  echo "deb http://HOSTIP:3142/archive.ubuntu.com/ubuntu $DISTRIB_CODENAME main universe" > $1/etc/apt/sources.list
+  echo "deb http://HOSTIP:3142/security.ubuntu.com/ubuntu $DISTRIB_CODENAME-security main universe" >> $1/etc/apt/sources.list
+  echo "deb http://HOSTIP:3142/archive.ubuntu.com/ubuntu $DISTRIB_CODENAME-updates main universe" >> $1/etc/apt/sources.list
+elif [ $DISTRIB_NAME = "Debian" ]; then
+  echo "deb http://HOSTIP:3142/ftp.debian.org/debian $DISTRIB_CODENAME main" > $1/etc/apt/sources.list
+  echo "deb http://HOSTIP:3142/security.debian.org/ $DISTRIB_CODENAME/updates main" >> $1/etc/apt/sources.list
+  echo "deb http://HOSTIP:3142/ftp.debian.org/debian $DISTRIB_CODENAME-updates main" >> $1/etc/apt/sources.list
+fi
 echo '127.0.1.1 gitian' >> /etc/hosts
 
 # If LXC

--- a/target-bin/bootstrap-fixup.in
+++ b/target-bin/bootstrap-fixup.in
@@ -13,6 +13,10 @@ elif [ $DISTRIB_NAME = "Debian" ]; then
   echo "deb http://HOSTIP:3142/ftp.debian.org/debian $DISTRIB_CODENAME main" > $1/etc/apt/sources.list
   echo "deb http://HOSTIP:3142/security.debian.org/ $DISTRIB_CODENAME/updates main" >> $1/etc/apt/sources.list
   echo "deb http://HOSTIP:3142/ftp.debian.org/debian $DISTRIB_CODENAME-updates main" >> $1/etc/apt/sources.list
+  # grub-legacy conflicts grub-pc dependencies
+  # No grub-legacy on Ubuntu, just on Debian
+  # Work around bcron-run conflict due to cron being removed
+  apt-get purge -y grub-legacy bcron-run &> /dev/null
 fi
 echo '127.0.1.1 gitian' >> /etc/hosts
 


### PR DESCRIPTION
Right now this is just KVM support. Selecting LXC and Debian just prints an error message for now. You need to use [my fork of vmbuilder](https://github.com/josephbisch/vmbuilder) for now if you want to use Debian guests.

The package manifest generation doesn't currently work for Debian guests, so that will have to be disabled if you want to test this PR with Debian guests.

One problem I see with this is that it adds a distro field to the descriptor (needed to determine the username), so there will be issues with using old descriptors. Now that I think about it some more, we could just assume Ubuntu if the distro is not specified.

Also, I'm making the assumption that no two distros will have overlapping suite names, because I'm not changing the naming format for the qcow2 files to include the distro. My justification for leaving the naming format the same is that I want these updates to "just work" as much as possible if someone is upgrading gitian-builder.

I wouldn't merge this PR until I get the package manifest generation fixed (it has something to do with broken packages when it attempts to reinstall the packages).