### PR TITLE
Fix debian i386

### DIFF
--- a/bin/make-base-vm
+++ b/bin/make-base-vm
@@ -107,15 +107,18 @@ fi
 
 addpkg=pciutils,build-essential,git-core,subversion,$LOCALE_PKG,wget,lsb-release
 
-KERNEL_PKG=linux-image-generic
-if [ $DISTRO = "debian" ]; then
-  KERNEL_PKG=
+if [ $DISTRO = "ubuntu" ]; then
+  # Need comma at end to work around an issue with apt for Debian <= Squeeze regarding empty strings
+  # https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=744940
+  # http://anonscm.debian.org/cgit/apt/apt.git/commit/?h=1.0.3&id=d99854cac4065bc7b337815fb2116269d58dab73
+  KERNEL_PKG=linux-image-generic,
 fi
 
 if [ $LXC = "1" ]; then
   addpkg=$addpkg,lxc
 else
-  addpkg=$addpkg,$KERNEL_PKG,grub-pc,openssh-server
+  # Lack of comma after KERNEL_PKG is not a typo
+  addpkg=$addpkg,${KERNEL_PKG}grub-pc,openssh-server
 fi
 
 # Remove cron to work around vmbuilder issue when umounting /dev on target

--- a/bin/make-base-vm
+++ b/bin/make-base-vm
@@ -94,10 +94,10 @@ fi
 
 if [ $DISTRO = "debian" -a $ARCH = "amd64" ]; then
   FLAVOUR=amd64
-elif [ $DISTRO = "debian" -a $ARCH = "i386" -a \($SUITE = "wheezy" -o $SUITE = "jessie" -o $SUITE = "stretch" -o $SUITE = "sid"\) ]; then
-  FLAVOUR=686-pae
-elif [ $DISTRO = "debian" ]; then
+elif [ $DISTRO = "debian" -a $ARCH = "i386" -a \($SUITE = "squeeze" -o $SUITE = "lenny" -o $SUITE = "etch" -o $SUITE = "sarge" -o $SUITE = "woody" -o $SUITE = "potato" -o $SUITE = "slink" -o $SUITE = "hamm" -o $SUITE = "bo" -o $SUITE = "rex" -o $SUITE = "buzz"\) ]; then
   FLAVOUR=686
+elif [ $DISTRO = "debian" ]; then
+  FLAVOUR=686-pae
 fi
 
 LOCALE_PKG=language-pack-en

--- a/bin/make-base-vm
+++ b/bin/make-base-vm
@@ -122,11 +122,16 @@ if [ $DISTRO = "ubuntu" ]; then
   KERNEL_PKG=linux-image-generic,
 fi
 
+GRUB_PKG=grub
+if [ $DISTRO = "ubuntu" ]; then
+  GRUB_PKG=grub-pc
+fi
+
 if [ $LXC = "1" ]; then
   addpkg=$addpkg,lxc
 else
   # Lack of comma after KERNEL_PKG is not a typo
-  addpkg=$addpkg,${KERNEL_PKG}grub-pc,openssh-server
+  addpkg=$addpkg,${KERNEL_PKG}${GRUB_PKG},openssh-server
 fi
 
 # Remove cron to work around vmbuilder issue when umounting /dev on target

--- a/bin/make-base-vm
+++ b/bin/make-base-vm
@@ -108,7 +108,15 @@ fi
 addpkg=pciutils,build-essential,git-core,subversion,$LOCALE_PKG,wget,lsb-release
 
 if [ $DISTRO = "ubuntu" ]; then
-  # Need comma at end to work around an issue with apt for Debian <= Squeeze regarding empty strings
+  # Need comma at end to work around an issue with apt for Debian <= Wheezy regarding empty strings
+  #
+  # If we left the comma down below when adding KERNEL_PKG to addpkg, the fact that KERNEL_PKG is undefined
+  # if DISTRO is debian would result in two commas in a row (,,), which is interpreted by apt-get as the
+  # package with the name empty string (""). This triggers a bug with apt versions < 1.0.3. So by adding the
+  # comma to the end of KERNEL_PKG, we are including that comma if the distro is ubuntu (and therefore we do
+  # have a kernel package that needs to be installed). If KERNEL_PKG is not set (i.e. we have Debian as the
+  # distro), then we don't add that extra comma and therefore, we don't end up with two commas in a row.
+  #
   # https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=744940
   # http://anonscm.debian.org/cgit/apt/apt.git/commit/?h=1.0.3&id=d99854cac4065bc7b337815fb2116269d58dab73
   KERNEL_PKG=linux-image-generic,

--- a/bin/make-base-vm
+++ b/bin/make-base-vm
@@ -94,8 +94,10 @@ fi
 
 if [ $DISTRO = "debian" -a $ARCH = "amd64" ]; then
   FLAVOUR=amd64
-elif [ $DISTRO = "debian" -a $ARCH = "i386" ]; then
-  FLAVOUR=i686-pae
+elif [ $DISTRO = "debian" -a $ARCH = "i386" -a \($SUITE = "wheezy" -o $SUITE = "jessie" -o $SUITE = "stretch" -o $SUITE = "sid"\) ]; then
+  FLAVOUR=686-pae
+elif [ $DISTRO = "debian" ]; then
+  FLAVOUR=686
 fi
 
 LOCALE_PKG=language-pack-en


### PR DESCRIPTION
Thanks to Georg Koppen for pointing out that the flavour for Debian should be 686-pae instead of i686-pae.

Also if it is Squeeze or earlier, it is just 686 instead of 686-pae.

The second commit is a work around to avoid an issue where an empty KERNEL_PKG (which was the case with Debian) resulted in two commas in a row in addpkg. The apt-get program interprets the lack of a package name between the commas as specifying the package name as being an empty string. That causes an issue for apt in Squeeze or earlier, due to the bug I linked to in the make-base-vm script.

This prepares gitian-builder to work with Squeeze guests. It still doesn't work for me at this point, but it appears to just require fixes to vmbuilder to get Squeeze working.