### PR TITLE
Set TUSER to ubuntu by default and update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,10 @@ If you have everything set-up properly, you should be able to:
     PATH=$PATH:$(pwd)/libexec
     make-clean-vm --suite lucid --arch i386
 
+    # on-target needs $DISTRO to be set to debian if using a Debian guest
+    # (when running gbuild, $DISTRO is set based on the descriptor, so this line isn't needed)
+    DiSTRO=debian
+
     # For LXC:
     LXC_ARCH=i386 LXC_SUITE=lucid on-target ls -la
 
@@ -161,7 +165,7 @@ After you've merged everybody's signatures, verify them:
 * Log files are captured to the _var_ directory
 * You can run the utilities in libexec by running `PATH="libexec:$PATH"`
 * To start the target VM run `start-target 32 lucid-i386` or `start-target 64 lucid-amd64`
-* To ssh into the target run `on-target` or `on-target -u root`
+* To ssh into the target run `on-target` (after setting $DISTRO to debian if using a Debian guest) or `on-target -u root`
 * On the target, the _build_ directory contains the code as it is compiled and _install_ contains intermediate libraries
 * By convention, the script in `<package>.yml` starts with any environment setup you would need to manually compile things on the target
 

--- a/libexec/copy-from-target
+++ b/libexec/copy-from-target
@@ -2,7 +2,7 @@
 
 . gconfig
 
-TUSER=$DISTRO
+TUSER=${DISTRO:-ubuntu}
 QUIET_FLAG=
 
 usage() {

--- a/libexec/copy-to-target
+++ b/libexec/copy-to-target
@@ -2,7 +2,7 @@
 
 . gconfig
 
-TUSER=$DISTRO
+TUSER=${DISTRO:-ubuntu}
 QUIET_FLAG=
 
 usage() {

--- a/libexec/on-target
+++ b/libexec/on-target
@@ -2,7 +2,7 @@
 
 . gconfig
 
-TUSER=$DISTRO
+TUSER=${DISTRO:-ubuntu}
 
 usage() {
   echo "Usage: ${0##*/} [OPTION]... <command>"


### PR DESCRIPTION
Now, if a user is using something like on-target directly, that user
doesn't need to set the DISTRO or TUSER variables if using Ubuntu guests
(so the scripts function the same as they did before Debian guest
support was added).