### PR TITLE
Set up IPv4 gateway automatically

### DIFF
--- a/etc/lxc.config.in
+++ b/etc/lxc.config.in
@@ -32,4 +32,6 @@ lxc.network.type = veth
 lxc.network.flags = up
 lxc.network.link = GUESTLINK
 lxc.network.ipv4 = GUESTIP/24
+lxc.network.ipv4.gateway = auto
+
 lxc.utsname = gitian


### PR DESCRIPTION
I need this to get internet access inside the LXC container in a Debian 8.2 VM. This sets the gateway to the host.
See also: https://github.com/bitcoin/bitcoin/pull/7060
