### PR TITLE
ssh: Replace deprecated dsa with rsa

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,8 +100,8 @@ Command-line `VBoxManage` must be in your `$PATH`.
 
 The final setup needed is to create an `ssh` key that will be used to login to the virtual machine:
 
-    ssh-keygen -t dsa -f var/id_dsa -N ""
-    ssh -p 2223 ubuntu@localhost 'mkdir -p .ssh && chmod 700 .ssh && cat >> .ssh/authorized_keys' < var/id_dsa.pub
+    ssh-keygen -t rsa -f var/id_rsa -N ""
+    ssh -p 2223 ubuntu@localhost 'mkdir -p .ssh && chmod 700 .ssh && cat >> .ssh/authorized_keys' < var/id_rsa.pub
 
 Then log into the vm and copy the `ssh` keys to root's `authorized_keys` file.
 

--- a/bin/make-base-vm
+++ b/bin/make-base-vm
@@ -81,8 +81,8 @@ fi
 
 mkdir -p var
 
-if [ ! -e var/id_dsa ]; then
-  ssh-keygen -t dsa -f var/id_dsa -N ""
+if [ ! -e var/id_rsa ]; then
+  ssh-keygen -t rsa -f var/id_rsa -N ""
 fi
 
 OUT=base-$SUITE-$ARCH
@@ -147,9 +147,9 @@ if [ $VBOX = "1" ]; then
   vagrant up "$NAME"
 
   vagrant ssh "$NAME" -c "sudo mkdir -p /root/.ssh && sudo chmod 700 /root/.ssh"
-  vagrant ssh "$NAME" -c "sudo sh -c 'cat >> /root/.ssh/authorized_keys'" < var/id_dsa.pub
+  vagrant ssh "$NAME" -c "sudo sh -c 'cat >> /root/.ssh/authorized_keys'" < var/id_rsa.pub
   vagrant ssh "$NAME" -c "sudo -u $DISTRO mkdir -p /home/$DISTRO/.ssh && sudo -u $DISTRO chmod 700 /home/$DISTRO/.ssh"
-  vagrant ssh "$NAME" -c "sudo sh -c 'cat >> /home/$DISTRO/.ssh/authorized_keys'" < var/id_dsa.pub
+  vagrant ssh "$NAME" -c "sudo sh -c 'cat >> /home/$DISTRO/.ssh/authorized_keys'" < var/id_rsa.pub
 
   VBoxManage snapshot "Gitian-$NAME" take "Gitian-Clean"
   vagrant suspend "$NAME"
@@ -184,7 +184,7 @@ else
   libexec/config-bootstrap-fixup
 
   rm -rf $OUT
-  env -i LANG=en_US.UTF-8 LC_ALL=en_US.UTF-8 sudo vmbuilder kvm $DISTRO --rootsize 10240 --arch=$ARCH --suite=$SUITE --addpkg=$addpkg --removepkg=$removepkg --ssh-key=var/id_dsa.pub --ssh-user-key=var/id_dsa.pub --mirror=$MIRROR --security-mirror=$SECURITY_MIRROR --dest=$OUT --flavour=$FLAVOUR --firstboot=`pwd`/target-bin/bootstrap-fixup
+  env -i LANG=en_US.UTF-8 LC_ALL=en_US.UTF-8 sudo vmbuilder kvm $DISTRO --rootsize 10240 --arch=$ARCH --suite=$SUITE --addpkg=$addpkg --removepkg=$removepkg --ssh-key=var/id_rsa.pub --ssh-user-key=var/id_rsa.pub --mirror=$MIRROR --security-mirror=$SECURITY_MIRROR --dest=$OUT --flavour=$FLAVOUR --firstboot=`pwd`/target-bin/bootstrap-fixup
   mv $OUT/*.qcow2 $OUT.qcow2
   rm -rf $OUT
   # bootstrap-fixup is done on first boot

--- a/libexec/copy-from-target
+++ b/libexec/copy-from-target
@@ -47,7 +47,7 @@ if [ $# = 0 ] ; then
 fi
 
 if [ -z "$USE_LXC" ]; then
-    scp $QUIET_FLAG -oConnectTimeout=30 -oNoHostAuthenticationForLocalhost=yes -i ${GITIAN_BASE:-.}/var/id_dsa -P $VM_SSH_PORT -r $TUSER@localhost:$1 $2
+    scp $QUIET_FLAG -oConnectTimeout=30 -oNoHostAuthenticationForLocalhost=yes -i ${GITIAN_BASE:-.}/var/id_rsa -P $VM_SSH_PORT -r $TUSER@localhost:$1 $2
 else
     config-lxc
     sudo $LXC_EXECUTE -n gitian -f var/lxc.config -- sudo -i -u $TUSER tar -C `dirname "$1"` -cf - `basename "$1"` | tar -C "$2" -xf -

--- a/libexec/copy-to-target
+++ b/libexec/copy-to-target
@@ -47,7 +47,7 @@ if [ $# = 0 ] ; then
 fi
 
 if [ -z "$USE_LXC" ]; then
-    scp $QUIET_FLAG -r -oConnectTimeout=30 -oNoHostAuthenticationForLocalhost=yes -i ${GITIAN_BASE:-.}/var/id_dsa -P $VM_SSH_PORT $1 $TUSER@localhost:$2
+    scp $QUIET_FLAG -r -oConnectTimeout=30 -oNoHostAuthenticationForLocalhost=yes -i ${GITIAN_BASE:-.}/var/id_rsa -P $VM_SSH_PORT $1 $TUSER@localhost:$2
 else
     config-lxc
     tar -C `dirname "$1"` -cf - `basename "$1"` | sudo $LXC_EXECUTE -n gitian -f var/lxc.config -- sudo -i -u $TUSER tar -C "$2" -xf -

--- a/libexec/on-target
+++ b/libexec/on-target
@@ -47,7 +47,7 @@ fi
 #fi
 
 if [ -z "$USE_LXC" ]; then
-    ssh -oConnectTimeout=30 -oNoHostAuthenticationForLocalhost=yes -i ${GITIAN_BASE:-.}/var/id_dsa -p $VM_SSH_PORT $TUSER@localhost $*
+    ssh -oConnectTimeout=30 -oNoHostAuthenticationForLocalhost=yes -i ${GITIAN_BASE:-.}/var/id_rsa -p $VM_SSH_PORT $TUSER@localhost $*
 else
     config-lxc
     sudo $LXC_EXECUTE -n gitian -f var/lxc.config -- sudo -u $TUSER $ENV -i -- $*


### PR DESCRIPTION
Fixes #106 

From http://www.openssh.com/txt/release-7.0:

```md
Potentially-incompatible Changes
--------------------------------

 * Support for ssh-dss, ssh-dss-cert-* host and user keys is disabled
   by default at run-time. These may be re-enabled using the
   instructions at http://www.openssh.com/legacy.html
