### PR TITLE
OpenSSH 7.0 compatibility for kvm gitian build

### DIFF
--- a/libexec/on-target
+++ b/libexec/on-target
@@ -47,7 +47,7 @@ fi
 #fi
 
 if [ -z "$USE_LXC" ]; then
-    ssh -oConnectTimeout=30 -oNoHostAuthenticationForLocalhost=yes -i ${GITIAN_BASE:-.}/var/id_rsa -p $VM_SSH_PORT $TUSER@localhost $*
+    ssh -oConnectTimeout=30 -oNoHostAuthenticationForLocalhost=yes -o PubkeyAcceptedKeyTypes=+ssh-dss -i ${GITIAN_BASE:-.}/var/id_rsa -p $VM_SSH_PORT $TUSER@localhost $*
 else
     config-lxc
     sudo $LXC_EXECUTE -n gitian -f var/lxc.config -- sudo -u $TUSER $ENV -i -- $*


### PR DESCRIPTION
OpenSSH 7.0 no longer has dsa enabled by default:

    debug1: Skipping ssh-dss key ./var/id_dsa for not in PubkeyAcceptedKeyTypes

This works around that. Another possibility would be to switch the key types but the other 'fast' key types such as `ssh-ed25519` aren't consistently supported in the targeted Ubuntu versions, and that would require regenerating base images, so I think this is the best workaround.

@luke-jr tested it
