### PR TITLE
Bugfix: copy-{to,from}-target: Strip trailing / from sources to avoid triggering special rsync behaviour

### DIFF
--- a/libexec/copy-from-target
+++ b/libexec/copy-from-target
@@ -47,7 +47,8 @@ if [ $# = 0 ] ; then
 fi
 
 if [ -z "$USE_LXC" ]; then
-    rsync --checksum -a $QUIET_FLAG -e "ssh -oConnectTimeout=30 -oNoHostAuthenticationForLocalhost=yes -i ${GITIAN_BASE:-.}/var/id_rsa -p $VM_SSH_PORT" "$TUSER@localhost:$1" "$2"
+    src="${1%/}"  # remove trailing / which triggers special rsync behaviour
+    rsync --checksum -a $QUIET_FLAG -e "ssh -oConnectTimeout=30 -oNoHostAuthenticationForLocalhost=yes -i ${GITIAN_BASE:-.}/var/id_rsa -p $VM_SSH_PORT" "$TUSER@localhost:${src}" "$2"
 else
     config-lxc
     sudo $LXC_EXECUTE -n gitian -f var/lxc.config -- sudo -i -u $TUSER tar -C `dirname "$1"` -cf - `basename "$1"` | tar -C "$2" -xf -

--- a/libexec/copy-to-target
+++ b/libexec/copy-to-target
@@ -47,7 +47,8 @@ if [ $# = 0 ] ; then
 fi
 
 if [ -z "$USE_LXC" ]; then
-    rsync --checksum -a $QUIET_FLAG -e "ssh -oConnectTimeout=30 -oNoHostAuthenticationForLocalhost=yes -i ${GITIAN_BASE:-.}/var/id_rsa -p $VM_SSH_PORT" "$1" "$TUSER@localhost:$2"
+    src="${1%/}"  # remove trailing / which triggers special rsync behaviour
+    rsync --checksum -a $QUIET_FLAG -e "ssh -oConnectTimeout=30 -oNoHostAuthenticationForLocalhost=yes -i ${GITIAN_BASE:-.}/var/id_rsa -p $VM_SSH_PORT" "${src}" "$TUSER@localhost:$2"
 else
     config-lxc
     tar -C `dirname "$1"` -cf - `basename "$1"` | sudo $LXC_EXECUTE -n gitian -f var/lxc.config -- sudo -i -u $TUSER tar -C "$2" -xf -


### PR DESCRIPTION
Without this, the caches end up in the wrong place (one level of directories gets removed)