### PR TITLE
Add support for Debian guests using LXC

### DIFF
--- a/bin/make-base-vm
+++ b/bin/make-base-vm
@@ -81,17 +81,14 @@ if [ $# != 0 ] ; then
   done
 fi
 
-if [ $DISTRO = "debian" -a $LXC = "1" ]; then
-  echo "There is no support for Debian guests using LXC currently. Please use KVM or another distro for now."
-  exit 1
-fi
-
 if [ $DISTRO = "ubuntu" ]; then
   MIRROR=$MIRROR_BASE/archive.ubuntu.com/ubuntu
   SECURITY_MIRROR=$MIRROR_BASE/security.ubuntu.com/ubuntu
+  components=main,universe
 elif [ $DISTRO = "debian" ]; then
   MIRROR=$MIRROR_BASE/ftp.debian.org/debian
   SECURITY_MIRROR=$MIRROR_BASE/security.debian.org/
+  components=main,contrib
 fi
 
 mkdir -p var
@@ -144,6 +141,9 @@ fi
 
 if [ $LXC = "1" ]; then
   addpkg=$addpkg,lxc
+  if [ $DISTRO = "debian" ]; then
+    addpkg=$addpkg,sudo
+  fi
 else
   # Lack of comma after KERNEL_PKG is not a typo
   addpkg=$addpkg,${KERNEL_PKG}${GRUB_PKG},openssh-server
@@ -185,7 +185,9 @@ if [ $LXC = "1" ]; then
     echo "sudo will preserve (some) env flags"
     preserve_env=yes # if you would want to set false then unset this variable
   fi
-  env -i LANG=en_US.UTF-8 LC_ALL=en_US.UTF-8 DEBOOTSTRAP_DIR="$DEBOOTSTRAP_DIR" sudo ${preserve_env+--preserve-env} debootstrap --arch=$ARCH --include=$addpkg --exclude=$removepkg --components=main,universe $SUITE $OUT-bootstrap $MIRROR
+  env -i LANG=en_US.UTF-8 LC_ALL=en_US.UTF-8 DEBOOTSTRAP_DIR="$DEBOOTSTRAP_DIR" sudo ${preserve_env+--preserve-env} debootstrap --arch=$ARCH --include=$addpkg --exclude=$removepkg --components=$components $SUITE $OUT-bootstrap $MIRROR
+  # Fix lxc issue
+  sudo cp $OUT-bootstrap/usr/lib/x86_64-linux-gnu/lxc/lxc-init $OUT-bootstrap/usr/sbin/init.lxc
   dd if=/dev/zero of=$OUT-lxc bs=1M count=1 seek=10240
   /sbin/mkfs.ext4 -F $OUT-lxc
   t=`mktemp -d gitian.XXXXXXXX`

--- a/bin/make-base-vm
+++ b/bin/make-base-vm
@@ -187,7 +187,17 @@ if [ $LXC = "1" ]; then
   fi
   env -i LANG=en_US.UTF-8 LC_ALL=en_US.UTF-8 DEBOOTSTRAP_DIR="$DEBOOTSTRAP_DIR" sudo ${preserve_env+--preserve-env} debootstrap --arch=$ARCH --include=$addpkg --exclude=$removepkg --components=$components $SUITE $OUT-bootstrap $MIRROR
   # Fix lxc issue
-  sudo cp $OUT-bootstrap/usr/lib/x86_64-linux-gnu/lxc/lxc-init $OUT-bootstrap/usr/sbin/init.lxc
+  if [ -f $OUT-bootstrap/usr/lib/lxc/lxc-init ]
+  then
+    sudo cp $OUT-bootstrap/usr/lib/lxc/lxc-init $OUT-bootstrap/usr/sbin/init.lxc
+  else
+    if [ $ARCH = "amd64" ]
+    then
+      sudo cp $OUT-bootstrap/usr/lib/x86_64-linux-gnu/lxc/lxc-init $OUT-bootstrap/usr/sbin/init.lxc
+    else
+      sudo cp $OUT-bootstrap/usr/lib/i386-linux-gnu/lxc/lxc-init $OUT-bootstrap/usr/sbin/init.lxc
+    fi
+  fi
   dd if=/dev/zero of=$OUT-lxc bs=1M count=1 seek=10240
   /sbin/mkfs.ext4 -F $OUT-lxc
   t=`mktemp -d gitian.XXXXXXXX`

--- a/target-bin/bootstrap-fixup.in
+++ b/target-bin/bootstrap-fixup.in
@@ -16,13 +16,14 @@ elif [ $DISTRIB_NAME = "Debian" ]; then
   # grub-legacy conflicts grub-pc dependencies
   # No grub-legacy on Ubuntu, just on Debian
   # Work around bcron-run conflict due to cron being removed
-  apt-get purge -y grub-legacy bcron-run &> /dev/null
+  # Needed for KVM, but apparently errors out for LXC, so the true ignores the error
+  apt-get purge -y grub-legacy bcron-run &> /dev/null || true
 fi
 echo '127.0.1.1 gitian' >> /etc/hosts
 
 # If LXC
 if grep /lxc/gitian /proc/1/cgroup > /dev/null; then
-  adduser --disabled-password --gecos ubuntu --quiet ubuntu || true
+  adduser --disabled-password --gecos ${DISTRIB_NAME,,} --quiet ${DISTRIB_NAME,,} || true
   apt-get remove -y rsyslog || true
   dpkg-divert --local --rename --add /sbin/initctl
   ln -sf /bin/true /sbin/initctl


### PR DESCRIPTION
I tested this using Arch Linux. I had to place the lxc-init program at /usr/sbin/init.lxc. That may just be because I am using Arch and the version of lxc in Arch was expecting the init program there.