### PR TITLE
Fixes Debian jessie lxc-init path issue

### DIFF
--- a/bin/make-base-vm
+++ b/bin/make-base-vm
@@ -193,9 +193,15 @@ if [ $LXC = "1" ]; then
   else
     if [ $ARCH = "amd64" ]
     then
-      sudo cp $OUT-bootstrap/usr/lib/x86_64-linux-gnu/lxc/lxc-init $OUT-bootstrap/usr/sbin/init.lxc
+      if [ -f $OUT-bootstrap/usr/lib/x86_64-linux-gnu/lxc/lxc-init ]
+      then
+        sudo cp $OUT-bootstrap/usr/lib/x86_64-linux-gnu/lxc/lxc-init $OUT-bootstrap/usr/sbin/init.lxc
+      fi
     else
-      sudo cp $OUT-bootstrap/usr/lib/i386-linux-gnu/lxc/lxc-init $OUT-bootstrap/usr/sbin/init.lxc
+      if [ -f $OUT-bootstrap/usr/lib/i386-linux-gnu/lxc/lxc-init ]
+      then
+        sudo cp $OUT-bootstrap/usr/lib/i386-linux-gnu/lxc/lxc-init $OUT-bootstrap/usr/sbin/init.lxc
+      fi
     fi
   fi
   dd if=/dev/zero of=$OUT-lxc bs=1M count=1 seek=10240


### PR DESCRIPTION
Original error:
```
I: Base system installed successfully.
cp: cannot stat 'base-jessie-amd64-bootstrap/usr/lib/x86_64-linux-gnu/lxc/lxc-init': No such file or directory
```

Also updates `bin/gbuild` so the hard-coded `ubuntu` username is switched out.

Contemplating making the Vagrantfile Debian-compatible too... but later.