### PR TITLE
stop-target: use poweroff instead of halt

### DIFF
--- a/libexec/stop-target
+++ b/libexec/stop-target
@@ -11,7 +11,7 @@ case $VMSW in
   KVM)
     if [ ! -e var/target.pid ]; then exit; fi
 
-    on-target -u root halt
+    on-target -u root poweroff
     sleep 5
 
     if [ ! -e var/target.pid ]; then exit; fi


### PR DESCRIPTION
When running Debian Jessie in KVM, using the halt command shuts down
all services but does not stop the qemu process. Using the poweroff
command avoids this problem.