### PR TITLE
Fix issues with newer versions of LXC

### DIFF
--- a/etc/lxc.config.in
+++ b/etc/lxc.config.in
@@ -22,6 +22,7 @@ lxc.cgroup.devices.allow = c 254:0 rwm
 # mounts points
 lxc.mount.entry=proc ROOTFS/proc proc nodev,noexec,nosuid 0 0
 lxc.mount.entry=sysfs ROOTFS/sys sysfs defaults  0 0
+lxc.mount.entry=shm dev/shm tmpfs rw,nodev,noexec,nosuid,relatime,mode=1777,create=dir 0 0
 
 # Container with network virtualized using a pre-configured bridge named br0 and
 # veth pair virtual network devices

--- a/target-bin/bootstrap-fixup.in
+++ b/target-bin/bootstrap-fixup.in
@@ -22,7 +22,7 @@ fi
 echo '127.0.1.1 gitian' >> /etc/hosts
 
 # If LXC
-if grep /lxc/gitian /proc/1/cgroup > /dev/null; then
+if grep /lxc/gitian /proc/1/cgroup > /dev/null || grep container=lxc /proc/1/environ > /dev/null; then
   adduser --disabled-password --gecos ${DISTRIB_NAME,,} --quiet ${DISTRIB_NAME,,} || true
   apt-get remove -y rsyslog || true
   dpkg-divert --local --rename --add /sbin/initctl


### PR DESCRIPTION
This fixes #147 and #128.

This is based on the changes from @jonasschnelli in #147, but I realized that the code in the if statement in `target-bin/bootstrap-fixup.in` wasn't being executed when using the Debian 9 host I was using to reproduce the issue. As you can see in the commit message, it is an issue with a change in the method for detecting that a guest is an LXC guest between LXC 1 and LXC 2. So now the adduser command actually executes and was sufficient to get rid of the sudo-related messages for me.

Also pinging @achow101, since @achow101 seemed to experience the same issue in #128.