### PR TITLE
Revert "Add LXC mount entry for shm"

### DIFF
--- a/etc/lxc.config.in
+++ b/etc/lxc.config.in
@@ -22,7 +22,6 @@ lxc.cgroup.devices.allow = c 254:0 rwm
 # mounts points
 lxc.mount.entry=proc ROOTFS/proc proc nodev,noexec,nosuid 0 0
 lxc.mount.entry=sysfs ROOTFS/sys sysfs defaults  0 0
-lxc.mount.entry=shm dev/shm tmpfs rw,nodev,noexec,nosuid,relatime,mode=1777,create=dir 0 0
 
 # Container with network virtualized using a pre-configured bridge named br0 and
 # veth pair virtual network devices


### PR DESCRIPTION
This reverts commit c2ff3f9025ab6d5c7bc8bbfbd72f79d40e119401.

That commit broke the use of gitian on debian jessie.

Fixes: #151 