### PR TITLE
Update vmbuilder references in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,9 +25,9 @@ From AUR:
 * [multipath-tools](https://aur.archlinux.org/packages/multipath-tools/) (for kpartx)
 * [ubuntu-keyring](https://aur.archlinux.org/packages/ubuntu-keyring/) (for making Ubuntu guests)
 
-From Launchpad:
+From newroco on GitHub:
 
-* [vmbuilder](https://launchpad.net/vmbuilder)
+* [vmbuilder](https://github.com/newroco/vmbuilder)
 
 Also, I had to modify the default /etc/sudoers file to uncomment the `secure_path` line, because vmbuilder isn't found otherwise when the `env -i ... sudo vmbuilder ...` line is executed (because the i flag resets the environment variables including the PATH).
 
@@ -72,9 +72,7 @@ Install virtualbox from http://www.virtualbox.org, and make sure `VBoxManage` is
 
 ## Debian Guests
 
-Gitian now supports Debian guests in addition to Ubuntu guests. Note that this doesn't mean you can allow the builders to choose to use either Debian or Ubuntu guests. The person creating the Gitian descriptor will need to choose a particular distro and suite for the guest and all builders must use that particular distro and suite, otherwise the software won't reproduce for everyone.
-
-The official vmbuilder only includes support for Ubuntu guests, so you need to install [Joseph Bisch's fork of vmbuilder](https://github.com/josephbisch/vmbuilder), which adds a Debian plugin.
+Gitian supports Debian guests in addition to Ubuntu guests. Note that this doesn't mean you can allow the builders to choose to use either Debian or Ubuntu guests. The person creating the Gitian descriptor will need to choose a particular distro and suite for the guest and all builders must use that particular distro and suite, otherwise the software won't reproduce for everyone.
 
 To create a Debian guest:
 
@@ -82,7 +80,7 @@ To create a Debian guest:
 
 There is currently no support for LXC Debian guests. There is just KVM support. LXC support for Debian guests is planned to be added soon.
 
-Only Debian Jessie guests have been tested with Gitian. Debian Jessie is the current stable release of Debian at this time. If you have success (or trouble) with other versions of Debian, please let us know.
+Only Debian Jessie guests have been tested with Gitian. If you have success (or trouble) with other versions of Debian, please let us know.
 
 If you are creating a Gitian descriptor, you can now specify a distro. If no distro is provided, the default is to assume Ubuntu. Since Ubuntu is assumed, older Gitian descriptors that don't specify a distro will still work as they always have.
 


### PR DESCRIPTION
Prompted by change of upstream for vmbuilder:
https://bugs.launchpad.net/ubuntu/+source/vm-builder/+bug/1260062/comments/15

Fixes #143, fixes #144. I believe those two issues are the only ones in our issue tracker that are fixed by changing to the new upstream.