### PR TITLE
Add support for multiarch

### DIFF
--- a/bin/gbuild
+++ b/bin/gbuild
@@ -94,6 +94,13 @@ EOF" if build_desc["sudo"] and @options[:allow_sudo]
     end
   end
 
+  if build_desc["multiarch"]
+    info "Adding multiarch support (log in var/install.log)"
+    for a in build_desc["multiarch"]
+      system! "on-target -u root dpkg --add-architecture #{a} > var/install.log 2>&1"
+    end
+  end
+
   info "Updating apt-get repository (log in var/install.log)"
   system! "on-target -u root apt-get update > var/install.log 2>&1"
 


### PR DESCRIPTION
Recent debian and ubuntu are using a system they call multiarch to handle different architectures. Activating multiarch is required to be able to install 32bits packages on 64bits system for instance.