### PR TITLE
Add support for update-alternatives

### DIFF
--- a/bin/gbuild
+++ b/bin/gbuild
@@ -100,6 +100,13 @@ EOF" if build_desc["sudo"] and @options[:allow_sudo]
   info "Installing additional packages (log in var/install.log)"
   system! "on-target -u root -e DEBIAN_FRONTEND=noninteractive apt-get --no-install-recommends -y install #{build_desc["packages"].join(" ")} > var/install.log 2>&1"
 
+  if build_desc["alternatives"]
+    info "Set alternatives (log in var/install.log)"
+    for a in build_desc["alternatives"]
+      system! "on-target -u root update-alternatives --set #{a["package"]} #{a["path"]} > var/install.log 2>&1"
+    end
+  end
+
   if @options[:upgrade] || system("on-target -u root '[ ! -e /var/cache/gitian/initial-upgrade ]'")
       info "Upgrading system, may take a while"
       system! "on-target -u root bash < target-bin/upgrade-system.sh > var/install.log 2>&1"


### PR DESCRIPTION
Recent ubuntu/debian upgraded mingw to use win32 thread by default instead of the mingw port of pthread. This is a problem because std::thread is not implemented for it, and numerous programs do not compile.

being able to update alternative to set the thread model to posix fixes it. This add the support required to be able to do so within the yml descriptor.