### PR TITLE
Enable builds to set disk image size (only for KVM)

### DIFF
--- a/bin/gbuild
+++ b/bin/gbuild
@@ -55,6 +55,11 @@ def build_one_configuration(suite, arch, build_desc)
   unless @options[:skip_image]
     info "Making a new image copy"
     system! "make-clean-vm --suite #{suite} --arch #{arch}"
+
+    if build_desc["disk_size"]
+      info "Growing target disk image"
+      system! "grow-target-vm --suite #{suite} --arch #{arch} --size #{build_desc["disk_size"]}"
+    end
   end
 
   info "Starting target"
@@ -76,7 +81,13 @@ def build_one_configuration(suite, arch, build_desc)
 %#{ENV['DISTRO'] || 'ubuntu'} ALL=(ALL) NOPASSWD: ALL
 EOF" if build_desc["sudo"] and @options[:allow_sudo]
 
+  info "Updating apt-get repository (log in var/install.log)"
+  system! "on-target -u root apt-get update > var/install.log 2>&1"
+
   info "Preparing build environment"
+  if build_desc["disk_size"]
+    system! "on-target -u root bash < target-bin/complete-resize.sh > var/install.log 2>&1"
+  end
   system! "on-target setarch #{@arches[arch]} bash < target-bin/init-build.sh"
 
   build_desc["files"].each do |filename|
@@ -93,9 +104,6 @@ EOF" if build_desc["sudo"] and @options[:allow_sudo]
       system! "copy-to-target #{@quiet_flag} cache/common/ cache/"
     end
   end
-
-  info "Updating apt-get repository (log in var/install.log)"
-  system! "on-target -u root apt-get update > var/install.log 2>&1"
 
   info "Installing additional packages (log in var/install.log)"
   system! "on-target -u root -e DEBIAN_FRONTEND=noninteractive apt-get --no-install-recommends -y install #{build_desc["packages"].join(" ")} > var/install.log 2>&1"

--- a/libexec/grow-target-vm
+++ b/libexec/grow-target-vm
@@ -1,0 +1,78 @@
+#!/bin/sh
+set -e
+
+SUITE=lucid
+ARCH=amd64
+SIZE=10G
+
+VMSW=KVM
+if [ -n "$USE_LXC" ]; then
+    VMSW=LXC
+elif [ -n "$USE_VBOX" ]; then
+    VMSW=VBOX
+fi
+
+usage() {
+  echo "Usage: ${0##*/} [OPTION]..."
+  echo "Resize target copy of the base client's disk image."
+  echo
+  cat << EOF
+  --help     display this help and exit
+  --suite U  build suite U instead of lucid
+  --arch A   build architecture A (e.g. i386) instead of amd64
+  --size N   new disk image size, in 
+EOF
+}
+
+if [ $# != 0 ] ; then
+  while true ; do
+    case "$1" in
+      --help|-h)
+        usage
+        exit 0
+        ;;
+      --suite|-s)
+        SUITE="$2"
+        shift 2
+        ;;
+      --arch|-a)
+        ARCH="$2"
+        shift 2
+        ;;
+      --size)
+        SIZE="$2"
+        shift 2
+        ;;
+      --*)
+        echo "unrecognized option $1"
+        exit 1
+        ;;
+      *)
+        break
+        ;;
+    esac
+  done
+fi
+
+export LXC_SUITE=$SUITE
+export LXC_ARCH=$ARCH
+
+OUT=target-$SUITE-$ARCH
+
+case $VMSW in
+  KVM)
+    out="$(qemu-img resize -f qcow2 "$OUT.qcow2" "$SIZE" || echo FAILED)"
+    if grep -q "shrink" <<<"$out"; then
+        echo "Disk image already large enough."
+        exit 0
+    elif grep -q "FAILED" <<<"$out"; then
+        exit 1
+    else
+        echo "$out"
+    fi
+    ;;
+  *)
+    echo "Growing disk images not supported with $VMSW" >&2
+    exit 1
+    ;;
+esac

--- a/target-bin/complete-resize.sh
+++ b/target-bin/complete-resize.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+DEBIAN_FRONTEND=noninteractive apt-get --no-install-recommends -y install expect-dev parted
+swapoff -a
+{ cat <<\EOF; sleep 1; while pidof parted; do sleep 1; done; } | unbuffer -p parted /dev/vda
+rm 2
+resizepart 1
+yes
+100%
+quit
+EOF
+resize2fs /dev/vda1


### PR DESCRIPTION
Trying to build Talos II firmware in gitian, but hitting disk space issues.

For now, this lets the yml file choose a larger disk size. Only supported in KVM.
