### PR TITLE
Add the option to use docker containers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,5 @@ base*
 sigs
 target-bin/bootstrap-fixup
 .vagrant
+docker
+*.Dockerfile

--- a/README.md
+++ b/README.md
@@ -48,6 +48,10 @@ If you'd like to use LXC mode instead, install it as follows:
 
     sudo apt-get install lxc
 
+If you'd like to use docker mode instead, install it as follows:
+
+    sudo apt-get install docker-ce
+
 ### Debian:
 
 See Ubuntu, and also run the following on Debian Jessie or newer:
@@ -100,6 +104,15 @@ If you are creating a Gitian descriptor, you can now specify a distro. If no dis
 Set the `USE_LXC` environment variable to use `LXC` instead of `KVM`:
 
     export USE_LXC=1
+
+### Docker
+
+    bin/make-base-vm --docker
+    bin/make-base-vm --docker --arch i386
+
+Set the `USE_DOCKER` environment variable to use `DOCKER` instead of `KVM`:
+
+    export USE_DOCKER=1
 
 ### VirtualBox
 

--- a/bin/make-base-vm
+++ b/bin/make-base-vm
@@ -7,6 +7,7 @@ ARCH=amd64
 MIRROR_BASE=http://${MIRROR_HOST:-127.0.0.1}:3142
 LXC=0
 VBOX=0
+DOCKER=0
 
 usage() {
   echo "Usage: ${0##*/} [OPTION]..."
@@ -19,6 +20,7 @@ usage() {
   --arch A    build architecture A (e.g. i386) instead of amd64
   --lxc       use lxc instead of kvm
   --vbox      use VirtualBox instead of kvm
+  --docker    use docker instead of kvm
 
   The MIRROR_HOST environment variable can be used to change the
   apt-cacher host.  It should be something that both the host and the
@@ -68,6 +70,10 @@ if [ $# != 0 ] ; then
         ;;
       --vbox)
         VBOX=1
+        shift 1
+        ;;
+      --docker)
+        DOCKER=1
         shift 1
         ;;
       --*)
@@ -152,6 +158,32 @@ fi
 
 # Remove cron to work around vmbuilder issue when umounting /dev on target
 removepkg=cron
+
+if [ $DOCKER = "1" ]; then
+
+  addpkg=`echo $addpkg | tr ',' ' '`
+
+  mkdir -p docker
+  cd docker
+
+  # Generate the dockerfile
+  cat << EOF > $OUT.Dockerfile
+FROM $DISTRO:$SUITE
+
+ENV DEBIAN_FRONTEND=noninteractive
+RUN apt-get update && apt-get --no-install-recommends -y install $addpkg
+
+RUN useradd -ms /bin/bash -U $DISTRO
+USER $DISTRO:$DISTRO
+WORKDIR /home/$DISTRO
+
+CMD ["sleep", "infinity"]
+EOF
+
+  docker build --pull -f $OUT.Dockerfile -t $OUT .
+
+  exit 0
+fi
 
 if [ $VBOX = "1" ]; then
   NAME="$SUITE-$ARCH"

--- a/libexec/copy-from-target
+++ b/libexec/copy-from-target
@@ -46,7 +46,9 @@ if [ $# = 0 ] ; then
   exit 1
 fi
 
-if [ -z "$USE_LXC" ]; then
+if [ -n "$USE_DOCKER" ]; then
+    docker cp gitian-target:"/home/$TUSER/$1" $2
+elif [ -z "$USE_LXC" ]; then
     src="${1%/}"  # remove trailing / which triggers special rsync behaviour
     rsync --checksum -a $QUIET_FLAG -e "ssh -oConnectTimeout=30 -oNoHostAuthenticationForLocalhost=yes -i ${GITIAN_BASE:-.}/var/id_rsa -p $VM_SSH_PORT" "$TUSER@localhost:${src}" "$2"
 else

--- a/libexec/copy-to-target
+++ b/libexec/copy-to-target
@@ -46,7 +46,10 @@ if [ $# = 0 ] ; then
   exit 1
 fi
 
-if [ -z "$USE_LXC" ]; then
+if [ -n "$USE_DOCKER" ]; then
+    docker exec -u $TUSER gitian-target mkdir -p "/home/$TUSER/$2"
+    docker cp "$1" gitian-target:"/home/$TUSER/$2"
+elif [ -z "$USE_LXC" ]; then
     src="${1%/}"  # remove trailing / which triggers special rsync behaviour
     rsync --checksum -a $QUIET_FLAG -e "ssh -oConnectTimeout=30 -oNoHostAuthenticationForLocalhost=yes -i ${GITIAN_BASE:-.}/var/id_rsa -p $VM_SSH_PORT" "${src}" "$TUSER@localhost:$2"
 else

--- a/libexec/make-clean-vm
+++ b/libexec/make-clean-vm
@@ -9,6 +9,8 @@ if [ -n "$USE_LXC" ]; then
     VMSW=LXC
 elif [ -n "$USE_VBOX" ]; then
     VMSW=VBOX
+elif [ -n "$USE_DOCKER" ]; then
+    VMSW=DOCKER
 fi
 
 usage() {
@@ -65,5 +67,8 @@ case $VMSW in
     ;;
   VBOX)
     VBoxManage snapshot "Gitian-${SUITE}-${ARCH}" restore "Gitian-Clean"
+    ;;
+  DOCKER)
+    true #Docker doesn't need to do anything
     ;;
 esac

--- a/libexec/on-target
+++ b/libexec/on-target
@@ -46,7 +46,9 @@ fi
 #  exit 1
 #fi
 
-if [ -z "$USE_LXC" ]; then
+if [ -n "$USE_DOCKER" ]; then
+    docker exec -u $TUSER -i gitian-target $*
+elif [ -z "$USE_LXC" ]; then
     ssh -oConnectTimeout=30 -oNoHostAuthenticationForLocalhost=yes -i ${GITIAN_BASE:-.}/var/id_rsa -p $VM_SSH_PORT $TUSER@localhost $*
 else
     config-lxc

--- a/libexec/start-target
+++ b/libexec/start-target
@@ -10,6 +10,8 @@ if [ -n "$USE_LXC" ]; then
     VMSW=LXC
 elif [ -n "$USE_VBOX" ]; then
     VMSW=VBOX
+elif [ -n "$USE_DOCKER" ]; then
+    VMSW=DOCKER
 fi
 
 case $VMSW in
@@ -33,5 +35,8 @@ case $VMSW in
   VBOX)
     VBoxManage startvm "Gitian-${2}" --type headless
     echo "Gitian-${2}" > var/target.vmname
+    ;;
+  DOCKER)
+    docker run -d --name gitian-target base-$SUFFIX:latest > /dev/null
     ;;
 esac

--- a/libexec/stop-target
+++ b/libexec/stop-target
@@ -5,6 +5,8 @@ if [ -n "$USE_LXC" ]; then
     VMSW=LXC
 elif [ -n "$USE_VBOX" ]; then
     VMSW=VBOX
+elif [ -n "$USE_DOCKER" ]; then
+    VMSW=DOCKER
 fi
 
 case $VMSW in
@@ -29,5 +31,9 @@ case $VMSW in
     if [ ! -e var/target.vmname ]; then exit; fi
     VBoxManage controlvm `cat var/target.vmname` savestate
     rm var/target.vmname
+    ;;
+  DOCKER)
+    docker container stop gitian-target > /dev/null
+    docker container rm gitian-target > /dev/null
     ;;
 esac


### PR DESCRIPTION
This PR adds another VM type: docker containers.

Since vmbuilder appears to be borked in recent versions (at least for how we are using it) and people have had issues with lxc in the past (including myself), I have added the option of using docker containers instead of LXC, KVM, or vbox. Setting up and using the docker containers is just as easy and seamless as the setup for lxc and kvm, except it should actually work since the docker people know what they are doing and have made it easy to actually setup and interact with docker containers.

`make-base-vm` now has a `--docker` switch to enable docker containers. Like with lxc, a `USE_DOCKER` environment variable needs to be set for the other scripts to use docker.

I have tested this with a build of Bitcoin Core 0.16.1rc1. The host is Ubuntu 18.04 while the container uses Ubuntu 14.04 as specified by the Bitcoin Core gitian descriptors. The binaries built matched those built by others using lxc or kvm (I am currently unable to compare with my own lxc and kvm builds because neither work for me).

While this PR supports using debian instead of ubuntu, I have no idea whether it actually works and I don't have anything to test that with.