### PR TITLE
[docker] Set permissions to container uid and group

### DIFF
--- a/libexec/copy-to-target
+++ b/libexec/copy-to-target
@@ -49,6 +49,7 @@ fi
 if [ -n "$USE_DOCKER" ]; then
     docker exec -u $TUSER gitian-target mkdir -p "/home/$TUSER/$2"
     docker cp "$1" gitian-target:"/home/$TUSER/$2"
+    docker exec -u root gitian-target chown -R $TUSER:$TUSER "/home/$TUSER/$2"
 elif [ -z "$USE_LXC" ]; then
     src="${1%/}"  # remove trailing / which triggers special rsync behaviour
     rsync --checksum -a $QUIET_FLAG -e "ssh -oConnectTimeout=30 -oNoHostAuthenticationForLocalhost=yes -i ${GITIAN_BASE:-.}/var/id_rsa -p $VM_SSH_PORT" "${src}" "$TUSER@localhost:$2"


### PR DESCRIPTION
docker cp has a bug where it uses the host machine's uid and group
for copied files and directories even though the copied files and
directories should use the container's user's uid and group. To fix
this, we run chown as root on the copied files and directories to
get the correct permissions.

This bug has caused problems for people whose uid:gid is not 1000:1000. This fixes those problems.