### PR TITLE
Kill unattended upgrades, to avoid apt-get failures

### DIFF
--- a/bin/gbuild
+++ b/bin/gbuild
@@ -72,6 +72,8 @@ def build_one_configuration(suite, arch, build_desc)
 
   system! "on-target true"
 
+  system! "on-target -u root '/etc/init.d/cron stop ; killall -vw apt.systemd.daily ; killall -vw unattended-upgrade ; true' > var/install.log 2>&1"
+
   system! "on-target -u root tee -a /etc/sudoers.d/#{ENV['DISTRO'] || 'ubuntu'} > /dev/null << EOF
 %#{ENV['DISTRO'] || 'ubuntu'} ALL=(ALL) NOPASSWD: ALL
 EOF" if build_desc["sudo"] and @options[:allow_sudo]


### PR DESCRIPTION
Ubuntu Bionic tries to upgrade the system at boot by default, which breaks gitian's usage of apt-get.