### PR TITLE
Increase the LXC disk size from 10241 MiB to 12 GiB

### DIFF
--- a/bin/make-base-vm
+++ b/bin/make-base-vm
@@ -264,7 +264,7 @@ if [ $LXC = "1" ]; then
       fi
     fi
   fi
-  dd if=/dev/zero of=$OUT-lxc bs=1M count=1 seek=10240
+  dd if=/dev/zero of=$OUT-lxc bs=1M count=1 seek=12287
   /sbin/mkfs.ext4 -F $OUT-lxc
   t=`mktemp -d gitian.XXXXXXXX`
   sudo mount $OUT-lxc $t


### PR DESCRIPTION
Since 1ae746f68f0e4409197365f775defd9ae901a96c, the LXC disk size is still 10241 MiB.
There are reports about related issues while building Bitcoin Core:
- https://github.com/bitcoin/bitcoin/issues/15541#issuecomment-470160960
- https://github.com/bitcoin/bitcoin/issues/15574

Over time, the sizes of both the Bitcoin Core repository and the cache have been increased. Some target architectures have been added.

This PR increases the LXC disk size from 10241 MiB to 12 GiB (originally suggested by @laanwj).

**Note for reviewers:** There is another [suggestion](https://github.com/bitcoin/bitcoin/pull/15549#issuecomment-470330012) from @laanwj:
>  or make the descriptor clean up the intermediate result after each host build.

As every new build is preceded by creating a fresh clean LXC image:
https://github.com/devrandom/gitian-builder/blob/63fe5d1de2a03e1d9b12b27e195753694487119a/libexec/make-clean-vm#L62
this suggestion seems to be not working.

