### PR TITLE
Do not leave configuration files of 'rsyslog' package

### DIFF
--- a/target-bin/bootstrap-fixup.in
+++ b/target-bin/bootstrap-fixup.in
@@ -24,7 +24,7 @@ echo '127.0.1.1 gitian' >> /etc/hosts
 # If LXC
 if grep /lxc/gitian /proc/1/cgroup > /dev/null || grep container=lxc /proc/1/environ > /dev/null; then
   adduser --disabled-password --gecos ${DISTRIB_NAME,,} --quiet ${DISTRIB_NAME,,} || true
-  apt-get remove -y rsyslog || true
+  apt-get purge -y rsyslog || true
   dpkg-divert --local --rename --add /sbin/initctl
   ln -sf /bin/true /sbin/initctl
   dpkg-divert --local --rename --add /usr/bin/ischroot


### PR DESCRIPTION
The configuration files of the removed `rsyslog` package cause needless work here:
https://github.com/devrandom/gitian-builder/blob/ba69d47c4453119dcb7af24638321df817112de6/target-bin/grab-packages.sh#L11