### PR TITLE
[CI-RUNNER] Output the build log directly to the STDOUT

### DIFF
--- a/bin/gbuild
+++ b/bin/gbuild
@@ -159,12 +159,11 @@ EOF" if build_desc["sudo"] and @options[:allow_sudo]
     script.puts "cd build"
     script.puts build_desc["script"]
   end
-
+  
+  info "Running build script (log in var/build.log)"
   if ENV["CI"]
-    info "Running build script"
     system! "on-target setarch #{@arches[arch]} bash -x < var/build-script 2>&1 | tee var/build.log"
   else
-    info "Running build script (log in var/build.log)"
     system! "on-target setarch #{@arches[arch]} bash -x < var/build-script > var/build.log 2>&1"
   end
 end

--- a/bin/gbuild
+++ b/bin/gbuild
@@ -159,7 +159,7 @@ EOF" if build_desc["sudo"] and @options[:allow_sudo]
     script.puts "cd build"
     script.puts build_desc["script"]
   end
-  
+
   info "Running build script (log in var/build.log)"
   if ENV["CI"]
     system! "on-target setarch #{@arches[arch]} bash -x < var/build-script 2>&1 | tee var/build.log"

--- a/bin/gbuild
+++ b/bin/gbuild
@@ -160,8 +160,13 @@ EOF" if build_desc["sudo"] and @options[:allow_sudo]
     script.puts build_desc["script"]
   end
 
-  info "Running build script (log in var/build.log)"
-  system! "on-target setarch #{@arches[arch]} bash -x < var/build-script > var/build.log 2>&1"
+  if ENV["CI"]
+    info "Running build script"
+    system! "on-target setarch #{@arches[arch]} bash -x < var/build-script"
+  else
+    info "Running build script (log in var/build.log)"
+    system! "on-target setarch #{@arches[arch]} bash -x < var/build-script > var/build.log 2>&1"
+  end
 end
 
 ################################

--- a/bin/gbuild
+++ b/bin/gbuild
@@ -162,7 +162,7 @@ EOF" if build_desc["sudo"] and @options[:allow_sudo]
 
   if ENV["CI"]
     info "Running build script"
-    system! "on-target setarch #{@arches[arch]} bash -x < var/build-script"
+    system! "on-target setarch #{@arches[arch]} bash -x < var/build-script 2>&1 | tee var/build.log"
   else
     info "Running build script (log in var/build.log)"
     system! "on-target setarch #{@arches[arch]} bash -x < var/build-script > var/build.log 2>&1"


### PR DESCRIPTION
For most CI's the constant output while running a task is necessary to keep the CI alive.
So whenever a CI is running gitian it should check the CI env to enable direct logs to the CI STDOUT.