### PR TITLE
Use apt-cacher in Docker image

### DIFF
--- a/bin/make-base-vm
+++ b/bin/make-base-vm
@@ -4,7 +4,6 @@ set -e
 DISTRO=ubuntu
 SUITE=xenial
 ARCH=amd64
-MIRROR_BASE=http://${MIRROR_HOST:-127.0.0.1}:3142
 LXC=0
 VBOX=0
 DOCKER=0
@@ -98,6 +97,13 @@ if [ $# != 0 ] ; then
   done
 fi
 
+if [ $DOCKER = "1" ]; then
+  MIRROR_DEFAULT=172.17.0.1
+else
+  MIRROR_DEFAULT=127.0.0.1
+fi
+MIRROR_BASE=http://${MIRROR_HOST:-$MIRROR_DEFAULT}:3142
+
 if [ $DISTRO = "ubuntu" ]; then
   MIRROR=$MIRROR_BASE/archive.ubuntu.com/ubuntu
   SECURITY_MIRROR=$MIRROR_BASE/security.ubuntu.com/ubuntu
@@ -189,6 +195,7 @@ if [ $DOCKER = "1" ]; then
 FROM $base_image
 
 ENV DEBIAN_FRONTEND=noninteractive
+RUN echo 'Acquire::http { Proxy "$MIRROR_BASE"; };' > /etc/apt/apt.conf.d/50cacher
 RUN apt-get update && apt-get --no-install-recommends -y install $addpkg
 
 RUN useradd -ms /bin/bash -U $DISTRO


### PR DESCRIPTION
The setup scripts install apt-cacher-ng but the docker image didn't use it.