### PR TITLE
copy-from-target: docker: Use tar to create files with the correct owner

### DIFF
--- a/libexec/copy-from-target
+++ b/libexec/copy-from-target
@@ -47,7 +47,8 @@ if [ $# = 0 ] ; then
 fi
 
 if [ -n "$USE_DOCKER" ]; then
-    docker cp gitian-target:"/home/$TUSER/$1" $2
+    # Use tar, so that files are created with the correct owner on the host
+    docker exec -u $TUSER gitian-target tar -C `dirname "$1"` -cf - `basename "$1"` | tar -C "$2" -xf -
 elif [ -z "$USE_LXC" ]; then
     src="${1%/}"  # remove trailing / which triggers special rsync behaviour
     rsync --checksum -a $QUIET_FLAG -e "ssh -oConnectTimeout=30 -oNoHostAuthenticationForLocalhost=yes -i ${GITIAN_BASE:-.}/var/id_rsa -p $VM_SSH_PORT" "$TUSER@localhost:${src}" "$2"


### PR DESCRIPTION
Some docker-like container management tools have issues setting the right owner with a plain `cp`. See https://github.com/containers/libpod/issues/3218.

Fix that by switching to the same tar command that is also used by lxc.