### PR TITLE
Fixes gbuild failure on OSX

### DIFF
--- a/bin/gbuild
+++ b/bin/gbuild
@@ -143,7 +143,7 @@ EOF" if build_desc["sudo"] and @options[:allow_sudo]
     build_desc["remotes"].each do |remote|
       dir = sanitize(remote["dir"], remote["dir"])
 
-      author_date = `cd inputs/#{dir} && git log --format=@%at -1 | date +"%F %T" -u -f -`.strip
+      author_date = `cd inputs/#{dir} && TZ=UTC git log --date='format-local:%F %T' --format="%ad" -1`.strip
       raise "error looking up author date in #{dir}" unless $?.exitstatus == 0
 
       system! "copy-to-target #{@quiet_flag} inputs/#{dir} build/"


### PR DESCRIPTION
## Problem: Fails on OSX
The current master `bin/gbuild` fails on OSX (Mojave) when formatting the [`author_date`](https://github.com/devrandom/gitian-builder/blob/master/bin/gbuild#L146). 

The following error is displayed:
```
...
date: illegal time format
usage: date [-jnRu] [-d dst] [-r seconds] [-t west] [-v[+|-]val[ymwdHMS]] ...
            [-f fmt date | [[[mm]dd]HH]MM[[cc]yy][.ss]] [+format]

bin/gbuild:147:in `block (2 levels) in build_one_configuration': error looking up author date in ... (RuntimeError)
```

## Reason
```ruby
author_date = `cd inputs/#{dir} && git log --format=@%at -1 | date +"%F %T" -u -f -`.strip
```

The OSX [`date`](https://ss64.com/osx/date.html) does not support the give arguments. 

## Solution
Instead of working with the `date` command and [incompatibilities](https://unix.stackexchange.com/questions/940/how-can-i-get-a-formatted-date-for-a-unix-timestamp-from-the-command-line), the proposed solution builds on `git` only:

```
TZ=UTC git log --date='format-local:%F %T' --format="%ad" -1`
```
* `TZ=UTC` - set local timezone to UTC
* [`--date`](https://git-scm.com/docs/git-log#Documentation/git-log.txt---dateltformatgt)
* [`%ad` -author date (format respects --date= option)](https://git-scm.com/docs/pretty-formats#Documentation/pretty-formats.txt-ad)

This converts the author date into UTC and the same destination format:
`2019-04-30 11:51:51`

## Tested with

* Ubuntu (Bionic)
* OSX (mojave)