### PR TITLE
gbuild: Allow for generic linux64 host

### DIFF
--- a/bin/gbuild
+++ b/bin/gbuild
@@ -10,11 +10,13 @@ require 'pathname'
 @bitness = {
   'i386' => 32,
   'amd64' => 64,
+  'linux64' => 64,
 }
 
 @arches = {
   'i386' => 'i386',
   'amd64' => 'x86_64',
+  'linux64' => 'linux64',
 }
 
 def system!(cmd)


### PR DESCRIPTION
I think gitian's initial design was that the gitian host arch is equal to the target host arch. This seems overly restrictive in light of cross-compilation. Thus, enable the generic `linux64` arch.