### PR TITLE
Don't ignore the target-bin/ directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ docker
 *.Dockerfile
 cache
 target-*
+!target-bin/


### PR DESCRIPTION
The target-* pattern intent is to ignore the target vm file when using
LXC, but it also matches the `target-bin/` directory which is an
undesired side-effect.