### PR TITLE
Add support for repository keys 

### DIFF
--- a/bin/gbuild
+++ b/bin/gbuild
@@ -75,10 +75,6 @@ def build_one_configuration(suite, arch, build_desc)
 
   system! "on-target true"
 
-  system! "on-target -u root tee -a /etc/sudoers.d/#{ENV['DISTRO'] || 'ubuntu'} > /dev/null << EOF
-%#{ENV['DISTRO'] || 'ubuntu'} ALL=(ALL) NOPASSWD: ALL
-EOF" if build_desc["sudo"] and @options[:allow_sudo]
-
   info "Preparing build environment"
   system! "on-target setarch #{@arches[arch]} bash < target-bin/init-build.sh"
 
@@ -146,6 +142,13 @@ EOF"
   end
   info "Creating package manifest"
   system! "on-target -u root bash < target-bin/grab-packages.sh > var/base-#{suitearch}.manifest"
+
+  if build_desc["sudo"] and @options[:allow_sudo]
+    system! "on-target -u root tee -a /etc/sudoers > /dev/null << EOF
+%#{ENV['DISTRO'] || 'ubuntu'} ALL=(ALL) NOPASSWD: ALL
+EOF"
+    info "Activating sudo"
+  end
 
   info "Creating build script (var/build-script)"
 

--- a/bin/gbuild
+++ b/bin/gbuild
@@ -104,21 +104,28 @@ EOF" if build_desc["sudo"] and @options[:allow_sudo]
     end
   end
 
-  if build_desc["repositories"]
-    info "Adding repositories to the sources list (log in var/install.log)"
-    for r in build_desc["repositories"]
-      system! "on-target -u root tee -a /etc/apt/sources.list >> var/install.log 2>&1 << EOF
-#{r["source"]}
-EOF"
-    end
-  end
-
   info "Updating apt-get repository (log in var/install.log)"
   system! "on-target -u root apt-get update >> var/install.log 2>&1"
 
   info "Installing additional packages (log in var/install.log)"
   system! "on-target -u root -e DEBIAN_FRONTEND=noninteractive apt-get --no-install-recommends -y install #{build_desc["packages"].join(" ")} >> var/install.log 2>&1"
 
+  if build_desc["repositories"]
+    info "Adding repositories to the sources list (log in var/install.log)"
+    system! "on-target -u root -e DEBIAN_FRONTEND=noninteractive apt-get --no-install-recommends -y install gnupg2 >> var/install.log 2>&1"
+    for r in build_desc["repositories"]
+      system! "on-target -u root tee -a /etc/apt/sources.list >> var/install.log 2>&1 << EOF
+#{r["source"]}
+EOF"
+      if r["key"] and r["name"]
+        system! "on-target -u root wget -O /tmp/#{r["name"]}.gpg #{r["key"]} >> var/install.log 2>&1"
+        system! "on-target -u root apt-key add /tmp/#{r["name"]}.gpg >> var/install.log 2>&1"
+      end
+    end
+    info "Updating new apt-get repositories (log in var/install.log)"
+    system! "on-target -u root apt-get update >> var/install.log 2>&1"
+  end
+  
   if build_desc["repositories"]
     for r in build_desc["repositories"]
       info "Installing additional packages from repository #{r["distribution"]} (log in var/install.log)"


### PR DESCRIPTION
Adds support for importing repository keys when one is specified in the YAML descriptor.

Example:

```
repositories:
- "distribution": "bionic"
  "source": "deb https://apt.kitware.com/ubuntu/ bionic main"
  "key": "https://apt.kitware.com/keys/kitware-archive-latest.asc"
  "name": "kitware"
  packages:
  - "cmake"
```