### PR TITLE
By default, cleanup the target after use

### DIFF
--- a/bin/gbuild
+++ b/bin/gbuild
@@ -221,6 +221,9 @@ OptionParser.new do |opts|
   opts.on("--skip-fetch", "skip fetching the latest git objects and refs from the remote source") do |v|
     @options[:skip_fetch] = v
   end
+  opts.on("--skip-cleanup", "skip cleaning up the target VM. this may be useful for copying additional files from the target after the build") do |v|
+    @options[:skip_cleanup] = v
+  end
 end.parse!
 
 if !ENV["USE_LXC"] and !ENV["USE_DOCKER"] and !ENV["USE_VBOX"] and !File.exist?("/dev/kvm")
@@ -346,6 +349,11 @@ suites.each do |suite|
     base_manifest = File.read("var/base-#{suite}-#{arch}.manifest")
     base_manifests["#{suite}-#{arch}"] = base_manifest
   end
+end
+
+unless @options[:skip_cleanup]
+  info "Cleaning up target"
+  system "stop-target"
 end
 
 out_dir = File.join(build_dir, "out")


### PR DESCRIPTION
After running gbuild, the VM is left running. This unnecessarily
consumes system resources if left alone.

I don't see a strong rationale for leaving the VM dangling after
running, especially since gbuild always cleans up the old VM at the start
of each execution (see line 54, where stop-target is called). By default,
the VM should be stopped. A new option has been added to override this
behavior, should it be useful in other configurations.