### PR TITLE
fix for spaces in names in bitcoin-core gitian.sigs

### DIFF
--- a/bin/gverify
+++ b/bin/gverify
@@ -19,7 +19,7 @@ def sanitize(str, where)
 end
 
 def sanitize_path(str, where)
-  raise "unsanitary string in #{where}" if (str =~ /[^@\w\/.:+-]/)
+  raise "unsanitary string in #{where}" if (str =~ /[^@\w\\ '\/.:+-]/)
   str
 end
 


### PR DESCRIPTION
Reference here:
https://github.com/bitcoin-core/gitian.sigs/issues/1316

Space in name breaking verify script with gitian sigs. Not sure if we want to allow spaces. If we do this fixes it.