### PR TITLE
Specifically fetch the requested commit

### DIFF
--- a/bin/gbuild
+++ b/bin/gbuild
@@ -318,7 +318,7 @@ build_desc["remotes"].each do |remote|
     system!("git init inputs/#{dir}")
   end
   if !@options[:skip_fetch]
-    system!("cd inputs/#{dir} && git fetch --update-head-ok #{sanitize_path(remote["url"], remote["url"])} +refs/tags/*:refs/tags/* +refs/heads/*:refs/heads/*")
+    system!("cd inputs/#{dir} && git fetch --update-head-ok #{sanitize_path(remote["url"], remote["url"])} #{commit}")
     system!("cd inputs/#{dir} && git checkout -q #{commit}")
     system!("cd inputs/#{dir} && git submodule update --init --recursive --force")
   end


### PR DESCRIPTION
Instead of fetching all tags and all heads, just fetch the requested commit. This accomplishes two things:

1. Avoids overzealous fetching of unrelated objects from the repo
2. Allows building commits which do not belong to any branch in a repository, such as merge commits generated by DrahtBot ([example](https://github.com/bitcoin/bitcoin/commit/4cd306c4d67aac6616196da0ed1ec91d6abd46a4)). Previously this was not possible.