### PR TITLE
Use ref name as tag name instead of the constant "tobuild"

### DIFF
--- a/bin/gbuild
+++ b/bin/gbuild
@@ -318,11 +318,11 @@ build_desc["remotes"].each do |remote|
     system!("git init inputs/#{dir}")
   end
   if !@options[:skip_fetch]
-    system!("cd inputs/#{dir} && git fetch -f --update-head-ok #{sanitize_path(remote["url"], remote["url"])} #{commit}:refs/tags/tobuild")
-    system!("cd inputs/#{dir} && git checkout -q tobuild")
+    system!("cd inputs/#{dir} && git fetch -f --update-head-ok #{sanitize_path(remote["url"], remote["url"])} #{commit}:refs/tags/#{commit}")
+    system!("cd inputs/#{dir} && git checkout -q refs/tags/#{commit}")
     system!("cd inputs/#{dir} && git submodule update --init --recursive --force")
   end
-  commit = `cd inputs/#{dir} && git log --format=%H -1 tobuild`.strip
+  commit = `cd inputs/#{dir} && git log --format=%H -1 refs/tags/#{commit}`.strip
   raise "error looking up commit for tag #{remote["commit"]}" unless $?.exitstatus == 0
   in_sums << "git:#{commit} #{dir}"
 end


### PR DESCRIPTION
@dongcarl @abitmore - here's yet another improvement to #238, naming the local tag the same as the ref that was requested on the command line.  This play better with `git describe --tags`.

Review / test would be welcome.

Fixes #243.