### PR TITLE
Allow for using docker with macOS

### DIFF
--- a/bin/make-base-vm
+++ b/bin/make-base-vm
@@ -193,12 +193,21 @@ if [ $DOCKER = "1" ]; then
     base_image="$DISTRO:$SUITE"
   fi
 
+  if [ $(uname) != "Darwin" ]; then
+    CACHELINE=$(cat << EOF0
+RUN echo 'Acquire::http { Proxy "$MIRROR_BASE"; };' > /etc/apt/apt.conf.d/50cacher
+EOF0
+)
+  else
+    # MacOS, no local debian cache
+    CACHELINE=""
+  fi
   # Generate the dockerfile
   cat << EOF > $OUT.Dockerfile
 FROM $base_image
 
 ENV DEBIAN_FRONTEND=noninteractive
-RUN echo 'Acquire::http { Proxy "$MIRROR_BASE"; };' > /etc/apt/apt.conf.d/50cacher
+$CACHELINE
 RUN apt-get update && apt-get --no-install-recommends -y install $addpkg
 
 RUN useradd -ms /bin/bash -U $DISTRO


### PR DESCRIPTION
Hi, I have been using gitian builder on macOS with some success. It only works with the docker vm mechanism, obviously. I found I needed to modify the script that generates the `Dockerfile` though, to not use a local debian cache in the `'Darwin'` case.  This MR is my modification.  With this modification it 100% works on docker.

This is by no means an exhaustive set of changes -- perhaps some usage patterns will still fail on macos -- but with this at least it works for 1 path -- building the container and running the builder.
