### PR TITLE
Enable use of USE_* variables with values 0 or 1

### DIFF
--- a/bin/gbuild
+++ b/bin/gbuild
@@ -43,7 +43,7 @@ def build_one_configuration(suite, arch, build_desc)
 
   bits = @bitness[arch] or raise "unknown architecture ${arch}"
 
-  if ENV["USE_LXC"]
+  if ENV["USE_LXC"] == "1"
       ENV["LXC_ARCH"] = arch
       ENV["LXC_SUITE"] = suite
   end
@@ -228,7 +228,7 @@ OptionParser.new do |opts|
   end
 end.parse!
 
-if !ENV["USE_LXC"] and !ENV["USE_DOCKER"] and !ENV["USE_VBOX"] and !File.exist?("/dev/kvm")
+if ENV["USE_LXC"] != "1" and ENV["USE_DOCKER"] != "1" and ENV["USE_VBOX"] != "1" and !File.exist?("/dev/kvm")
     $stderr.puts "\n************* WARNING: kvm not loaded, this will probably not work out\n\n"
 end
 
@@ -273,7 +273,7 @@ docker_image_digests = build_desc["docker_image_digests"] || []
 # if docker_image_digests are supplied, it must be the same length as suites
 if docker_image_digests.size > 0 and suites.size != docker_image_digests.size
   raise "`suites` and `docker_image_digests` must both be the same size if both are supplied"
-elsif ENV["USE_DOCKER"] and docker_image_digests.size > 0 and suites.size == docker_image_digests.size
+elsif ENV["USE_DOCKER"] == "1" and docker_image_digests.size > 0 and suites.size == docker_image_digests.size
   suites = docker_image_digests
 end
 

--- a/libexec/copy-from-target
+++ b/libexec/copy-from-target
@@ -46,10 +46,10 @@ if [ $# = 0 ] ; then
   exit 1
 fi
 
-if [ "$USE_DOCKER" -eq 1 ]; then
+if [ "$USE_DOCKER" = "1" ]; then
     # Use tar, so that files are created with the correct owner on the host
     docker exec -u $TUSER gitian-target tar -C `dirname "$1"` -cf - `basename "$1"` | tar -C "$2" -xf -
-elif [ "$USE_LXC" -eq 1 ]; then
+elif [ "$USE_LXC" = "1" ]; then
     config-lxc
     sudo $LXC_EXECUTE -n gitian -f var/lxc.config -- sudo -i -u $TUSER tar -C `dirname "$1"` -cf - `basename "$1"` | tar -C "$2" -xf -
 else

--- a/libexec/copy-from-target
+++ b/libexec/copy-from-target
@@ -46,13 +46,13 @@ if [ $# = 0 ] ; then
   exit 1
 fi
 
-if [ -n "$USE_DOCKER" ]; then
+if [ "$USE_DOCKER" -eq 1 ]; then
     # Use tar, so that files are created with the correct owner on the host
     docker exec -u $TUSER gitian-target tar -C `dirname "$1"` -cf - `basename "$1"` | tar -C "$2" -xf -
-elif [ -z "$USE_LXC" ]; then
-    src="${1%/}"  # remove trailing / which triggers special rsync behaviour
-    rsync --checksum -a $QUIET_FLAG -e "ssh -oConnectTimeout=30 -oNoHostAuthenticationForLocalhost=yes -i ${GITIAN_BASE:-.}/var/id_rsa -p $VM_SSH_PORT" "$TUSER@localhost:${src}" "$2"
-else
+elif [ "$USE_LXC" -eq 1 ]; then
     config-lxc
     sudo $LXC_EXECUTE -n gitian -f var/lxc.config -- sudo -i -u $TUSER tar -C `dirname "$1"` -cf - `basename "$1"` | tar -C "$2" -xf -
+else
+    src="${1%/}"  # remove trailing / which triggers special rsync behaviour
+    rsync --checksum -a $QUIET_FLAG -e "ssh -oConnectTimeout=30 -oNoHostAuthenticationForLocalhost=yes -i ${GITIAN_BASE:-.}/var/id_rsa -p $VM_SSH_PORT" "$TUSER@localhost:${src}" "$2"
 fi

--- a/libexec/copy-to-target
+++ b/libexec/copy-to-target
@@ -46,14 +46,14 @@ if [ $# = 0 ] ; then
   exit 1
 fi
 
-if [ -n "$USE_DOCKER" ]; then
+if [ "$USE_DOCKER" -eq 1 ]; then
     docker exec -u $TUSER gitian-target mkdir -p "/home/$TUSER/$2"
     docker cp "$1" gitian-target:"/home/$TUSER/$2"
     docker exec -u root gitian-target chown -R $TUSER:$TUSER "/home/$TUSER/$2"
-elif [ -z "$USE_LXC" ]; then
-    src="${1%/}"  # remove trailing / which triggers special rsync behaviour
-    rsync --checksum -a $QUIET_FLAG -e "ssh -oConnectTimeout=30 -oNoHostAuthenticationForLocalhost=yes -i ${GITIAN_BASE:-.}/var/id_rsa -p $VM_SSH_PORT" "${src}" "$TUSER@localhost:$2"
-else
+elif [ "$USE_LXC" -eq 1 ]; then
     config-lxc
     tar -C `dirname "$1"` -cf - `basename "$1"` | sudo $LXC_EXECUTE -n gitian -f var/lxc.config -- sudo -i -u $TUSER tar -C "$2" -xf -
+else
+    src="${1%/}"  # remove trailing / which triggers special rsync behaviour
+    rsync --checksum -a $QUIET_FLAG -e "ssh -oConnectTimeout=30 -oNoHostAuthenticationForLocalhost=yes -i ${GITIAN_BASE:-.}/var/id_rsa -p $VM_SSH_PORT" "${src}" "$TUSER@localhost:$2"
 fi

--- a/libexec/copy-to-target
+++ b/libexec/copy-to-target
@@ -46,11 +46,11 @@ if [ $# = 0 ] ; then
   exit 1
 fi
 
-if [ "$USE_DOCKER" -eq 1 ]; then
+if [ "$USE_DOCKER" = "1" ]; then
     docker exec -u $TUSER gitian-target mkdir -p "/home/$TUSER/$2"
     docker cp "$1" gitian-target:"/home/$TUSER/$2"
     docker exec -u root gitian-target chown -R $TUSER:$TUSER "/home/$TUSER/$2"
-elif [ "$USE_LXC" -eq 1 ]; then
+elif [ "$USE_LXC" = "1" ]; then
     config-lxc
     tar -C `dirname "$1"` -cf - `basename "$1"` | sudo $LXC_EXECUTE -n gitian -f var/lxc.config -- sudo -i -u $TUSER tar -C "$2" -xf -
 else

--- a/libexec/gconfig
+++ b/libexec/gconfig
@@ -1,5 +1,5 @@
 VM_SSH_PORT=2223
-if [ "$USE_LXC" -eq 1 ]; then
+if [ "$USE_LXC" = "1" ]; then
   if [ -z "$LXC_EXECUTE" ]; then
     ver=`lxc-start --version`
     if dpkg --compare-versions $ver ge 1.0.0 ; then

--- a/libexec/gconfig
+++ b/libexec/gconfig
@@ -1,5 +1,5 @@
 VM_SSH_PORT=2223
-if [ -n "$USE_LXC" ]; then
+if [ "$USE_LXC" -eq 1 ]; then
   if [ -z "$LXC_EXECUTE" ]; then
     ver=`lxc-start --version`
     if dpkg --compare-versions $ver ge 1.0.0 ; then

--- a/libexec/make-clean-vm
+++ b/libexec/make-clean-vm
@@ -5,11 +5,11 @@ SUITE=xenial
 ARCH=amd64
 
 VMSW=KVM
-if [ -n "$USE_LXC" ]; then
+if [ "$USE_LXC" -eq 1 ]; then
     VMSW=LXC
-elif [ -n "$USE_VBOX" ]; then
+elif [ "$USE_VBOX" -eq 1 ]; then
     VMSW=VBOX
-elif [ -n "$USE_DOCKER" ]; then
+elif [ "$USE_DOCKER" -eq 1 ]; then
     VMSW=DOCKER
 fi
 

--- a/libexec/make-clean-vm
+++ b/libexec/make-clean-vm
@@ -5,11 +5,11 @@ SUITE=xenial
 ARCH=amd64
 
 VMSW=KVM
-if [ "$USE_LXC" -eq 1 ]; then
+if [ "$USE_LXC" = "1" ]; then
     VMSW=LXC
-elif [ "$USE_VBOX" -eq 1 ]; then
+elif [ "$USE_VBOX" = "1" ]; then
     VMSW=VBOX
-elif [ "$USE_DOCKER" -eq 1 ]; then
+elif [ "$USE_DOCKER" = "1" ]; then
     VMSW=DOCKER
 fi
 

--- a/libexec/on-target
+++ b/libexec/on-target
@@ -46,11 +46,11 @@ fi
 #  exit 1
 #fi
 
-if [ -n "$USE_DOCKER" ]; then
+if [ "$USE_DOCKER" -eq 1 ]; then
     docker exec -u $TUSER -i gitian-target $*
-elif [ -z "$USE_LXC" ]; then
-    ssh -oConnectTimeout=30 -oNoHostAuthenticationForLocalhost=yes -i ${GITIAN_BASE:-.}/var/id_rsa -p $VM_SSH_PORT $TUSER@localhost $*
-else
+elif [ "$USE_LXC" -eq 1 ]; then
     config-lxc
     sudo $LXC_EXECUTE -n gitian -f var/lxc.config -- sudo -u $TUSER $ENV -i -- $*
+else
+    ssh -oConnectTimeout=30 -oNoHostAuthenticationForLocalhost=yes -i ${GITIAN_BASE:-.}/var/id_rsa -p $VM_SSH_PORT $TUSER@localhost $*
 fi

--- a/libexec/on-target
+++ b/libexec/on-target
@@ -46,9 +46,9 @@ fi
 #  exit 1
 #fi
 
-if [ "$USE_DOCKER" -eq 1 ]; then
+if [ "$USE_DOCKER" = "1" ]; then
     docker exec -u $TUSER -i gitian-target $*
-elif [ "$USE_LXC" -eq 1 ]; then
+elif [ "$USE_LXC" = "1" ]; then
     config-lxc
     sudo $LXC_EXECUTE -n gitian -f var/lxc.config -- sudo -u $TUSER $ENV -i -- $*
 else

--- a/libexec/start-target
+++ b/libexec/start-target
@@ -6,11 +6,11 @@ ARCH=qemu$1
 SUFFIX=$2
 
 VMSW=KVM
-if [ "$USE_LXC" -eq 1 ]; then
+if [ "$USE_LXC" = "1" ]; then
     VMSW=LXC
-elif [ "$USE_VBOX" -eq 1 ]; then
+elif [ "$USE_VBOX" = "1" ]; then
     VMSW=VBOX
-elif [ "$USE_DOCKER" -eq 1 ]; then
+elif [ "$USE_DOCKER" = "1" ]; then
     VMSW=DOCKER
 fi
 

--- a/libexec/start-target
+++ b/libexec/start-target
@@ -6,11 +6,11 @@ ARCH=qemu$1
 SUFFIX=$2
 
 VMSW=KVM
-if [ -n "$USE_LXC" ]; then
+if [ "$USE_LXC" -eq 1 ]; then
     VMSW=LXC
-elif [ -n "$USE_VBOX" ]; then
+elif [ "$USE_VBOX" -eq 1 ]; then
     VMSW=VBOX
-elif [ -n "$USE_DOCKER" ]; then
+elif [ "$USE_DOCKER" -eq 1 ]; then
     VMSW=DOCKER
 fi
 

--- a/libexec/stop-target
+++ b/libexec/stop-target
@@ -1,11 +1,11 @@
 #!/bin/sh
 
 VMSW=KVM
-if [ "$USE_LXC" -eq 1 ]; then
+if [ "$USE_LXC" = "1" ]; then
     VMSW=LXC
-elif [ "$USE_VBOX" -eq 1 ]; then
+elif [ "$USE_VBOX" = "1" ]; then
     VMSW=VBOX
-elif [ "$USE_DOCKER" -eq 1 ]; then
+elif [ "$USE_DOCKER" = "1" ]; then
     VMSW=DOCKER
 fi
 

--- a/libexec/stop-target
+++ b/libexec/stop-target
@@ -1,11 +1,11 @@
 #!/bin/sh
 
 VMSW=KVM
-if [ -n "$USE_LXC" ]; then
+if [ "$USE_LXC" -eq 1 ]; then
     VMSW=LXC
-elif [ -n "$USE_VBOX" ]; then
+elif [ "$USE_VBOX" -eq 1 ]; then
     VMSW=VBOX
-elif [ -n "$USE_DOCKER" ]; then
+elif [ "$USE_DOCKER" -eq 1 ]; then
     VMSW=DOCKER
 fi
 


### PR DESCRIPTION
#### Problematic

When you're using `USE_DOCKER`, `USE_LXC` or `USE_VBOX`, if you specify mutliple variables you're going slowly to some undefined behavior.

Also, if you set a variable with the value 0, `USE_LXC = 0`  the software will see it as using LXC because it's checking if the variable is set whatever the value is.

#### Suggestion

I added some value check when those variables are used, mainly checking if the value is equal 1. This allow users to specify `USE_*` with the value 0 or 1 and to set multiple variables at once with less conflict.

But still some undefined behavior, like what happen if multiple variables are set to 1.
