### PR TITLE
gverify: Remove gpg import with --recv-keys

### DIFF
--- a/bin/gverify
+++ b/bin/gverify
@@ -113,7 +113,6 @@ Dir.foreach(release_path) do |signer_dir|
   end
 
   result = YAML.load_file(result_path)
-  system("#{program} --keyserver pgp.mit.edu --recv-keys `#{program} --quiet --batch --verify \"#{File.join(signer_path, 'signature.pgp')}\" \"#{result_path}\" 2>&1 | head -n1 | grep \"key ID\" | awk '{ print $15 }'` > /dev/null 2>&1")
   out = `#{program} --quiet --batch --verify \"#{sig_path}\" \"#{result_path}\" 2>&1`
   if $? != 0
     out.each_line do |line|


### PR DESCRIPTION
Suggesting removing import of gpg key during gverify which use `--recv-keys`.

Look like it's trying to retrieve a key using a `signature.pgp` file. The current command will fail if this file is not provided, with the command/line becoming useless.

You do not give any explanation about this file, documentation of `gverify`  ask to import public key before running the command.
I'm suspecting a deprecated feature, and I may be wrong but it doesn't seem to be generated by the program.