### PR TITLE
make-clean-vm: Specify backing_fmt to qemu-img explicitly

### DIFF
--- a/libexec/make-clean-vm
+++ b/libexec/make-clean-vm
@@ -53,7 +53,7 @@ OUT=target-$SUITE-$ARCH
 
 case $VMSW in
   KVM)
-    qemu-img create -f qcow2 -o backing_file="$BASE.qcow2" "$OUT.qcow2"
+    qemu-img create -f qcow2 -o backing_fmt=qcow2,backing_file="$BASE.qcow2" "$OUT.qcow2"
     ;;
   LXC)
     cp -a $BASE $OUT


### PR DESCRIPTION
Recent versions of qemu require it now