### PR TITLE
Revert ubuntu mirror url changes from #273

### DIFF
--- a/bin/make-base-vm
+++ b/bin/make-base-vm
@@ -111,7 +111,7 @@ fi
 MIRROR_BASE=http://${MIRROR_HOST:-$MIRROR_DEFAULT}:3142
 
 if [ $DISTRO = "ubuntu" ]; then
-  MIRROR=$MIRROR_BASE/old-releases.ubuntu.com/ubuntu
+  MIRROR=$MIRROR_BASE/archive.ubuntu.com/ubuntu
   SECURITY_MIRROR=$MIRROR_BASE/security.ubuntu.com/ubuntu
   components=main,universe
 elif [ $DISTRO = "debian" ]; then


### PR DESCRIPTION
Changes to the Ubuntu mirror url were reverted for `target-bin/bootstrap-fixup.in` from #274, but not for `bin/make-base-vm` from #273. 

This reverts the latter because that is currently blocking the creation of new base images with debootstrap.