### PR TITLE
Fix LXC detect in boostrap-fixup.in for newer Linux host systems

### DIFF
--- a/target-bin/bootstrap-fixup.in
+++ b/target-bin/bootstrap-fixup.in
@@ -31,7 +31,7 @@ fi
 echo '127.0.1.1 gitian' >> /etc/hosts
 
 # If LXC
-if grep /lxc/gitian /proc/1/cgroup > /dev/null || grep container=lxc /proc/1/environ > /dev/null; then
+if grep /lxc/gitian /proc/1/cgroup > /dev/null || grep container=lxc /proc/1/environ > /dev/null || grep lxc- /proc/1/comm > /dev/null; then
   adduser --disabled-password --gecos ${DISTRIB_NAME,,} --quiet ${DISTRIB_NAME,,} || true
   apt-get purge -y rsyslog || true
   dpkg-divert --local --rename --add /sbin/initctl


### PR DESCRIPTION
Newer host systems such as Debian 12 use control group v2 and so the heuristics for this `if` statement that attempts to detect LXC fail on such systems. 

This additional `||` clause checks the process name of PID 1 which is `init` outside a container and `lxc-execute` inside a container.

This is tested and works on Debian-12 and also does not introduce any regressions.